### PR TITLE
Fix directive parsing in code blocks + align code block config (closes #9, #10)

### DIFF
--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -71,7 +71,7 @@ const buildConfigWithMemoryDB = async () => {
               className: '[&_li::marker]:!text-cyan-200/90',
               options: {
                 langs: [...DEFAULT_CODE_LANGS, 'latex', 'r'],
-                lineNumbers: false,
+                lineNumbers: true,
               },
             },
           },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/node": "22.19.9",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/unist": "^3.0.3",
     "copyfiles": "2.4.1",
     "cross-env": "^7.0.3",
     "eslint": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valkyrianlabs/payload-markdown",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Beautiful, production-ready Markdown rendering and editor support for Payload CMS, with Tailwind styling and extensible parsing (MDX, plugins, and custom formatting coming soon).",
   "repository": {
     "url": "https://github.com/valkyrianlabs/payload-markdown"
@@ -24,6 +24,11 @@
       "import": "./dist/exports/server.js",
       "types": "./dist/exports/server.d.ts",
       "default": "./dist/exports/server.js"
+    },
+    "./advanced": {
+      "import": "./dist/exports/advanced.js",
+      "types": "./dist/exports/advanced.d.ts",
+      "default": "./dist/exports/advanced.js"
     }
   },
   "files": [
@@ -113,6 +118,11 @@
         "import": "./dist/exports/server.js",
         "types": "./dist/exports/server.d.ts",
         "default": "./dist/exports/server.js"
+      },
+      "./advanced": {
+        "import": "./dist/exports/advanced.js",
+        "types": "./dist/exports/advanced.d.ts",
+        "default": "./dist/exports/advanced.js"
       }
     },
     "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1

--- a/src/blocks/MarkdownBlock/Component.tsx
+++ b/src/blocks/MarkdownBlock/Component.tsx
@@ -1,4 +1,4 @@
-import type { MarkdownBlockProps } from '../../core/types.js'
+import type { MarkdownBlockProps } from '../../types/core.js'
 
 import { MarkdownRenderer } from '../../components/MarkdownRenderer/Component.js'
 import { resolveMarkdownBlockDefaults } from '../../runtime/index.js'

--- a/src/blocks/MarkdownBlock/config.ts
+++ b/src/blocks/MarkdownBlock/config.ts
@@ -1,12 +1,12 @@
 import type { Block } from 'payload'
 
-import { blocksParams } from '../../field/BlocksParams/config.js'
+import { vlMdConfig } from '../../field/Config/config.js'
 import { markdownField } from '../../field/MarkdownField/config.js'
 
 export const MarkdownBlock: Block = {
   slug: 'vlMdBlock',
   fields: [
-    blocksParams(),
+    vlMdConfig(),
     markdownField({
       name: 'content',
       label: 'Markdown Content',

--- a/src/components/MarkdownRenderer/Component.tsx
+++ b/src/components/MarkdownRenderer/Component.tsx
@@ -5,7 +5,7 @@ import type {
   MarkdownRendererScope,
   MarkdownSize,
   MarkdownVariant,
-} from '../../core/types.js'
+} from '../../types/core.js'
 
 import { compileMarkdown } from '../../core/renderMarkdown.js'
 import {

--- a/src/core/codeToHtml.ts
+++ b/src/core/codeToHtml.ts
@@ -1,6 +1,8 @@
+import type { Element, ElementContent, Text } from 'hast'
+
 import { createHighlighter, type ShikiTransformer } from 'shiki'
 
-import type { CodeBlockOptions } from './types.js'
+import type { CodeBlockOptions } from '../types/core.js'
 
 export const DEFAULT_CODE_LANG = 'text'
 export const DEFAULT_CODE_THEME = 'github-dark'
@@ -87,6 +89,37 @@ function resolveCodeBlockOptions(
   }
 }
 
+function isText(node: ElementContent): node is Text {
+  return node.type === 'text'
+}
+
+function isElement(node: ElementContent): node is Element {
+  return node.type === 'element'
+}
+
+function isEmptyText(node: Text): boolean {
+  return node.value === ''
+}
+
+function isVisuallyEmptyLine(node: Element): boolean {
+  if (node.children.length === 0) return true
+
+  return node.children.every((child) => {
+    if (isText(child)) return isEmptyText(child)
+
+    if (isElement(child)) {
+      if (child.children.length === 0) return true
+
+      return child.children.every((grandchild) => {
+        if (isText(grandchild)) return isEmptyText(grandchild)
+        return false
+      })
+    }
+
+    return false
+  })
+}
+
 /**
  * Builds the Shiki transformer pipeline used to normalize and enhance
  * rendered fenced code blocks.
@@ -130,17 +163,22 @@ function buildTransformers(
         'margin: 0',
       ])
 
-      if (node.children)
+      if (node.children) {
         node.children = node.children.filter((child) => {
           if (child.type !== 'text') return true
-          return child.value.trim().length > 0
+
+          // Shiki inserts raw newline separator text nodes between rendered line spans.
+          // Those create fake blank rows once each line is display:block.
+          // Remove only those separators, not actual line content.
+          return !/^\r?\n$/.test(child.value)
         })
+      }
     },
 
     line(node, line) {
       if (!useEnhanced && !lineNumbers) return
 
-      const isEmptyLine = node.children.length === 0
+      const isEmptyLine = isVisuallyEmptyLine(node)
       const styleBits = ['display: block', 'position: relative', 'white-space: pre']
 
       if (lineNumbers) {
@@ -154,6 +192,7 @@ function buildTransformers(
             style: [
               'position: absolute',
               'left: 0',
+              'top: 0',
               `width: ${metrics.numberWidthRem}rem`,
               'text-align: right',
               'color: #7c8596',
@@ -162,6 +201,7 @@ function buildTransformers(
               'pointer-events: none',
               'font-variant-numeric: tabular-nums',
               'font-feature-settings: "tnum"',
+              'line-height: inherit',
             ].join('; '),
           },
           tagName: 'span',
@@ -171,23 +211,27 @@ function buildTransformers(
       }
 
       if (isEmptyLine) {
-        node.children.push({
-          type: 'element',
-          children: [{ type: 'text', value: '' }],
-          properties: {
-            class: 'md-empty-line',
-            style: [
-              'display: inline-block',
-              'width: 0',
-              'height: 1em',
-              'overflow: hidden',
-              'vertical-align: top',
-              'user-select: none',
-              'pointer-events: none',
-            ].join('; '),
+        const lineNumberNode = lineNumbers ? node.children[0] : null
+
+        node.children = [
+          ...(lineNumberNode ? [lineNumberNode] : []),
+          {
+            type: 'element',
+            children: [{ type: 'text', value: '\u00A0' }],
+            properties: {
+              class: 'md-empty-line',
+              style: [
+                'display: inline-block',
+                'min-height: 1em',
+                'line-height: inherit',
+                'visibility: hidden',
+                'user-select: none',
+                'pointer-events: none',
+              ].join('; '),
+            },
+            tagName: 'span',
           },
-          tagName: 'span',
-        })
+        ]
       }
 
       if (useEnhanced || lineNumbers)

--- a/src/core/plugins/rehypeApplyLayoutClasses.ts
+++ b/src/core/plugins/rehypeApplyLayoutClasses.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'unified'
 
 import { visit } from 'unist-util-visit'
 
-import type { MarkdownConfig } from '../types.js'
+import type { MarkdownConfig } from '../../types/core.js'
 
 function compactClassNames(...values: Array<string | undefined>): string[] {
   return values.flatMap((value) => value?.split(/\s+/).filter(Boolean) ?? [])

--- a/src/core/plugins/remarkCompileLayouts.ts
+++ b/src/core/plugins/remarkCompileLayouts.ts
@@ -1,9 +1,17 @@
-import type { Content, Heading, Paragraph, Root, Text } from 'mdast'
+import type { Heading, Root, RootContent } from 'mdast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import type { Plugin } from 'unified'
 
 type LayoutName = '2col' | '3col' | 'section'
 type LayoutNode = ContainerDirective | Root
+
+type LayoutToken =
+  | { action: 'close'; type: 'vlLayoutToken' }
+  | { action: 'closeGrid'; type: 'vlLayoutToken' }
+  | { action: 'closeSection'; type: 'vlLayoutToken' }
+  | { action: 'open'; name: LayoutName; type: 'vlLayoutToken' }
+
+type AppendableRootContent = Exclude<RootContent, LayoutToken>
 
 type LayoutFrame = {
   cellHeadingDepth?: number
@@ -12,46 +20,16 @@ type LayoutFrame = {
   parentHeadingDepth?: number
 }
 
-type Sentinel =
-  | { name: LayoutName; type: 'open' }
-  | { type: 'close' }
-  | { type: 'closeGrid' }
-  | { type: 'closeSection' }
-
-function isParagraph(node: Content): node is Paragraph {
-  return node.type === 'paragraph'
-}
-
-function isHeading(node: Content): node is Heading {
+function isHeading(node: RootContent): node is Heading {
   return node.type === 'heading'
 }
 
-function isText(node: Paragraph['children'][number]): node is Text {
-  return node.type === 'text'
+function isLayoutToken(node: RootContent): node is LayoutToken {
+  return node.type === 'vlLayoutToken'
 }
 
-function getParagraphText(node: Paragraph): null | string {
-  if (!node.children.every(isText)) return null
-  return node.children
-    .map((child) => child.value)
-    .join('')
-    .trim()
-}
-
-function getSentinel(node: Content): null | Sentinel {
-  if (!isParagraph(node)) return null
-
-  const text = getParagraphText(node)
-  if (!text) return null
-
-  if (text === '%%VL_OPEN:section%%') return { name: 'section', type: 'open' }
-  if (text === '%%VL_OPEN:2col%%') return { name: '2col', type: 'open' }
-  if (text === '%%VL_OPEN:3col%%') return { name: '3col', type: 'open' }
-  if (text === '%%VL_CLOSE%%') return { type: 'close' }
-  if (text === '%%VL_CLOSE_GRID%%') return { type: 'closeGrid' }
-  if (text === '%%VL_CLOSE_SECTION%%') return { type: 'closeSection' }
-
-  return null
+function isAppendableRootContent(node: RootContent): node is AppendableRootContent {
+  return node.type !== 'vlLayoutToken'
 }
 
 function makeDirective(
@@ -71,8 +49,8 @@ function makeDirective(
   }
 }
 
-function getChildren(node: LayoutNode): Content[] {
-  return node.children as Content[]
+function getChildren(node: LayoutNode): AppendableRootContent[] {
+  return node.children as AppendableRootContent[]
 }
 
 function top<T>(arr: T[]): T {
@@ -129,8 +107,8 @@ function closeThroughSection(stack: LayoutFrame[]): boolean {
   return true
 }
 
-export const remarkLayoutSentinels: Plugin<[], Root> = () => {
-  return (tree: Root, file) => {
+export const remarkCompileLayouts: Plugin<[], Root> = () => {
+  return (tree, file) => {
     const input = [...tree.children]
     const rebuiltRoot: Root = { ...tree, children: [] }
     const stack: LayoutFrame[] = [{ name: 'root', node: rebuiltRoot }]
@@ -138,31 +116,27 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
 
     let currentHeadingDepth: number | undefined
 
-    const append = (node: Content) => getChildren(top(stack).node).push(node)
+    const append = (node: AppendableRootContent) => getChildren(top(stack).node).push(node)
 
     for (const node of input) {
-      const sentinel = getSentinel(node)
-
-      if (sentinel) {
-        if (sentinel.type === 'open') {
-          if (sentinel.name === 'section') {
+      if (isLayoutToken(node)) {
+        if (node.action === 'open') {
+          if (node.name === 'section') {
             const next = makeDirective('section')
             append(next)
             stack.push({ name: 'section', node: next })
             continue
           }
 
-          // Opening a new grid while already inside a grid inside a section
-          // rolls over to a sibling grid automatically.
           closeActiveGridInsideSection(stack)
 
           const parentDepth = currentHeadingDepth ?? 1
           const cellDepth = parentDepth + 1
-          const next = makeDirective(sentinel.name, parentDepth, cellDepth)
+          const next = makeDirective(node.name, parentDepth, cellDepth)
 
           append(next)
           stack.push({
-            name: sentinel.name,
+            name: node.name,
             cellHeadingDepth: cellDepth,
             node: next,
             parentHeadingDepth: parentDepth,
@@ -170,7 +144,7 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
           continue
         }
 
-        if (sentinel.type === 'close') {
+        if (node.action === 'close') {
           if (stack.length === 1) {
             warnings.push('Encountered ::: with no open layout block.')
             continue
@@ -180,7 +154,7 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
           continue
         }
 
-        if (sentinel.type === 'closeGrid') {
+        if (node.action === 'closeGrid') {
           if (!closeActiveGrid(stack)) {
             warnings.push('Encountered :::endcol with no open grid.')
             continue
@@ -189,7 +163,7 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
           continue
         }
 
-        if (sentinel.type === 'closeSection') {
+        if (node.action === 'closeSection') {
           if (!closeThroughSection(stack))
             warnings.push('Encountered :::end or :::endsection with no open section.')
 
@@ -203,11 +177,7 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
         if (isGridName(currentFrame.name)) {
           const parentDepth = currentFrame.parentHeadingDepth
 
-          // Same-level heading as the parent section remains inside the grid.
-          // Only a true ascent above the parent depth auto-closes the grid.
-          if (typeof parentDepth === 'number' && node.depth < parentDepth) {
-            closeTop(stack)
-          }
+          if (typeof parentDepth === 'number' && node.depth < parentDepth) closeTop(stack)
         }
 
         currentHeadingDepth = node.depth
@@ -215,7 +185,7 @@ export const remarkLayoutSentinels: Plugin<[], Root> = () => {
         continue
       }
 
-      append(node)
+      if (isAppendableRootContent(node)) append(node)
     }
 
     while (stack.length > 1) {

--- a/src/core/plugins/remarkLiftLayoutDirectives.ts
+++ b/src/core/plugins/remarkLiftLayoutDirectives.ts
@@ -1,0 +1,46 @@
+import type { Paragraph, Root, RootContent, Text } from 'mdast'
+import type { Plugin } from 'unified'
+
+import type { LayoutToken } from '../../types/layoutToken.js'
+
+function isParagraph(node: RootContent): node is Paragraph {
+  return node.type === 'paragraph'
+}
+
+function isText(node: Paragraph['children'][number]): node is Text {
+  return node.type === 'text'
+}
+
+function getParagraphText(node: Paragraph): null | string {
+  if (!node.children.every(isText)) return null
+
+  return node.children
+    .map((child) => child.value)
+    .join('')
+    .trim()
+}
+
+function parseLayoutDirective(text: string): LayoutToken | null {
+  if (text === ':::section') return { name: 'section', type: 'vlLayoutToken', action: 'open' }
+  if (text === ':::2col') return { name: '2col', type: 'vlLayoutToken', action: 'open' }
+  if (text === ':::3col') return { name: '3col', type: 'vlLayoutToken', action: 'open' }
+  if (text === ':::endcol') return { type: 'vlLayoutToken', action: 'closeGrid' }
+  if (text === ':::endsection') return { type: 'vlLayoutToken', action: 'closeSection' }
+  if (text === ':::end') return { type: 'vlLayoutToken', action: 'closeSection' }
+  if (text === ':::') return { type: 'vlLayoutToken', action: 'close' }
+
+  return null
+}
+
+export const remarkLiftLayoutDirectives: Plugin<[], Root> = () => {
+  return (tree) => {
+    tree.children = tree.children.map((node): RootContent => {
+      if (!isParagraph(node)) return node
+
+      const text = getParagraphText(node)
+      if (!text) return node
+
+      return parseLayoutDirective(text) ?? node
+    })
+  }
+}

--- a/src/core/renderMarkdown.ts
+++ b/src/core/renderMarkdown.ts
@@ -11,23 +11,13 @@ import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 import { visit } from 'unist-util-visit'
 
-import type { MarkdownConfig, RenderMarkdownOptions, RenderMarkdownResult } from './types.js'
+import type { MarkdownConfig, RenderMarkdownOptions, RenderMarkdownResult } from '../types/core.js'
 
 import { codeToHtml } from './codeToHtml.js'
 import { rehypeApplyLayoutClasses } from './plugins/rehypeApplyLayoutClasses.js'
+import { remarkCompileLayouts } from './plugins/remarkCompileLayouts.js'
 import { remarkLayoutDirectives } from './plugins/remarkLayoutDirectives.js'
-import { remarkLayoutSentinels } from './plugins/remarkLayoutSentinels.js'
-
-function normalizeLayoutSyntax(input: string): string {
-  return input
-    .replace(/^[ \t]*:::section[ \t]*$/gim, '%%VL_OPEN:section%%')
-    .replace(/^[ \t]*:::2col[ \t]*$/gim, '%%VL_OPEN:2col%%')
-    .replace(/^[ \t]*:::3col[ \t]*$/gim, '%%VL_OPEN:3col%%')
-    .replace(/^[ \t]*:::endcol[ \t]*$/gim, '%%VL_CLOSE_GRID%%')
-    .replace(/^[ \t]*:::endsection[ \t]*$/gim, '%%VL_CLOSE_SECTION%%')
-    .replace(/^[ \t]*:::end[ \t]*$/gim, '%%VL_CLOSE_SECTION%%')
-    .replace(/^[ \t]*:::[ \t]*$/gm, '%%VL_CLOSE%%')
-}
+import { remarkLiftLayoutDirectives } from './plugins/remarkLiftLayoutDirectives.js'
 
 function extractCodeLanguage(
   className?: Array<number | string> | boolean | null | number | string  ,
@@ -135,19 +125,18 @@ export async function compileMarkdown(
   const warnings: string[] = []
 
   try {
-    const normalizedMarkdown = normalizeLayoutSyntax(markdown)
-
     const file = await unified()
       .use(remarkParse)
       .use(remarkGfm)
-      .use(remarkLayoutSentinels)
+      .use(remarkLiftLayoutDirectives)
+      .use(remarkCompileLayouts)
       .use(remarkLayoutDirectives)
       .use(remarkRehype, { allowDangerousHtml: false })
       .use(rehypeShikiCodeBlocks, config.options)
       .use(rehypeSanitize, sanitizeSchema)
       .use(rehypeApplyLayoutClasses, config)
       .use(rehypeStringify)
-      .process(normalizedMarkdown)
+      .process(markdown)
 
     return {
       html: String(file),

--- a/src/exports/advanced.ts
+++ b/src/exports/advanced.ts
@@ -1,3 +1,3 @@
-export { vlMdCodeBlockConfig } from '../field/CodeBlock/config.js'
+export { vlMdCodeBlockConfig } from '../field/CodeBlockConfig/config.js'
 export { vlMdConfig } from '../field/Config/config.js'
 export { vlMdTailwindField } from '../field/Tailwind/config.js'

--- a/src/exports/advanced.ts
+++ b/src/exports/advanced.ts
@@ -1,0 +1,3 @@
+export { vlMdCodeBlockConfig } from '../field/CodeBlock/config.js'
+export { vlMdConfig } from '../field/Config/config.js'
+export { vlMdTailwindField } from '../field/Tailwind/config.js'

--- a/src/field/CodeBlock/config.ts
+++ b/src/field/CodeBlock/config.ts
@@ -6,7 +6,7 @@ export type CodeBlockParams = {
   name?: string
 }
 
-export function codeBlockParams(options: CodeBlockParams = {}): Field {
+export function vlMdCodeBlockConfig(options: CodeBlockParams = {}): Field {
   const {
     name = 'code_params',
     admin,

--- a/src/field/CodeBlockConfig/config.ts
+++ b/src/field/CodeBlockConfig/config.ts
@@ -98,23 +98,6 @@ export function vlMdCodeBlockConfig(options: CodeBlockParams = {}): Field {
         ],
       },
       {
-        name: 'langs',
-        type: 'array',
-        admin: {
-          description: 'The list of languages to load for syntax highlighting this code block. ' +
-            'Defaults to a common set of popular languages. ' +
-            'Note that loading many languages may impact performance, so it\'s best to only include the ones you need.',
-        },
-        fields: [
-          {
-            name: 'lang',
-            type: 'text',
-            label: 'Language',
-          }
-        ],
-        label: 'Shiki Languages'
-      },
-      {
         type: 'row',
         fields: [
           {

--- a/src/field/CodeBlockParams/config.ts
+++ b/src/field/CodeBlockParams/config.ts
@@ -98,6 +98,23 @@ export function codeBlockParams(options: CodeBlockParams = {}): Field {
         ],
       },
       {
+        name: 'langs',
+        type: 'array',
+        admin: {
+          description: 'The list of languages to load for syntax highlighting this code block. ' +
+            'Defaults to a common set of popular languages. ' +
+            'Note that loading many languages may impact performance, so it\'s best to only include the ones you need.',
+        },
+        fields: [
+          {
+            name: 'lang',
+            type: 'text',
+            label: 'Language',
+          }
+        ],
+        label: 'Shiki Languages'
+      },
+      {
         type: 'row',
         fields: [
           {
@@ -110,7 +127,7 @@ export function codeBlockParams(options: CodeBlockParams = {}): Field {
             label: 'Show Line Numbers'
           },
           {
-            name: 'prettyCodeBlocks',
+            name: 'enhancedCodeBlocks',
             type: 'checkbox',
             admin: {
               description: 'Whether to apply the plugin\'s enhanced code block formatting. ' +
@@ -121,19 +138,8 @@ export function codeBlockParams(options: CodeBlockParams = {}): Field {
                 'Set this to false if you want to preserve raw Shiki block styling as much as possible.',
             },
             defaultValue: true,
-            label: 'Pretty Code Blocks',
+            label: 'Enhanced Code Blocks',
           },
-          {
-            name: 'highlightLines',
-            type: 'checkbox',
-            admin: {
-              description: 'Whether to enable line highlighting for the code block. ' +
-                'When enabled, you can specify lines to highlight by including a line number list in the code block\'s language declaration. ' +
-                'For example, a declaration of "js{1,4-5}" would highlight lines 1, 4, and 5 in the block.',
-            },
-            defaultValue: false,
-            label: 'Highlight Lines',
-          }
         ]
       }
     ],

--- a/src/field/Config/config.ts
+++ b/src/field/Config/config.ts
@@ -1,7 +1,7 @@
 import type { Field, GroupField } from 'payload'
 
-import { codeBlockParams } from '../CodeBlockParams/config.js'
-import { tailwindField } from '../TailwindField/config.js'
+import { vlMdCodeBlockConfig } from '../CodeBlock/config.js'
+import { vlMdTailwindField } from '../Tailwind/config.js'
 
 export type BlocksParamsOptions = {
   admin?: Partial<GroupField['admin']>
@@ -9,7 +9,7 @@ export type BlocksParamsOptions = {
   name?: string
 }
 
-export function blocksParams(options: BlocksParamsOptions = {}): Field {
+export function vlMdConfig(options: BlocksParamsOptions = {}): Field {
   const { name = 'md-params', admin, label = 'Markdown Blocks Params' } = options
 
   return {
@@ -35,28 +35,28 @@ export function blocksParams(options: BlocksParamsOptions = {}): Field {
           condition: (_, siblingData) => !!siblingData?.enable,
         },
         fields: [
-          tailwindField({
+          vlMdTailwindField({
             name: 'wrapperClassName',
             admin: {
               description: 'Additional Tailwind classes to apply to the block wrapper element.',
             },
             label: 'Tailwind Wrapper Classes',
           }),
-          tailwindField({
+          vlMdTailwindField({
             name: 'className',
             admin: {
               description: 'Additional Tailwind classes to apply to the block element itself.',
             },
             label: 'Tailwind Markdown Element Classes',
           }),
-          tailwindField({
+          vlMdTailwindField({
             name: 'sectionClassName',
             admin: {
               description: 'Additional Tailwind classes to apply to the block section element.',
             },
             label: 'Tailwind Markdown Section Classes',
           }),
-          tailwindField({
+          vlMdTailwindField({
             name: 'columnClassName',
             admin: {
               description: 'Additional Tailwind classes to apply to the block column element.',
@@ -129,7 +129,7 @@ export function blocksParams(options: BlocksParamsOptions = {}): Field {
               },
             ],
           },
-          codeBlockParams({ name: 'options' }),
+          vlMdCodeBlockConfig({ name: 'options' }),
         ],
       },
     ],

--- a/src/field/Config/config.ts
+++ b/src/field/Config/config.ts
@@ -1,6 +1,6 @@
 import type { Field, GroupField } from 'payload'
 
-import { vlMdCodeBlockConfig } from '../CodeBlock/config.js'
+import { vlMdCodeBlockConfig } from '../CodeBlockConfig/config.js'
 import { vlMdTailwindField } from '../Tailwind/config.js'
 
 export type BlocksParamsOptions = {

--- a/src/field/Tailwind/config.ts
+++ b/src/field/Tailwind/config.ts
@@ -8,7 +8,7 @@ export type TailwindFieldOptions = {
   required?: boolean
 }
 
-export function tailwindField(options: TailwindFieldOptions = {}): Field {
+export function vlMdTailwindField(options: TailwindFieldOptions = {}): Field {
   const {
     name = 'vlTailwindsField',
     admin,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,10 +1,10 @@
-import type { MarkdownConfig } from '../core/types.js'
 import type {
   ConfigOptions,
   DualMarkdownFieldConfig,
   PayloadMarkdownCollectionConfig,
   PayloadMarkdownConfig,
 } from '../types.js'
+import type { MarkdownConfig } from '../types/core.js'
 
 export type PayloadMarkdownResolvedSettings = {
   collections: Partial<Record<string, PayloadMarkdownCollectionConfig | true>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { CollectionSlug, TextField } from 'payload'
 
-import type { MarkdownConfig } from './core/types.js'
+import type { MarkdownConfig } from './types/core.js'
 
 export type DualMarkdownFieldConfig = {
   blocks?: MarkdownConfig

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,17 +1,4 @@
-/**
- * @import {} from 'mdast-util-directive'
- */
-
 import type { JSX, ReactNode } from 'react'
-
-import 'mdast-util-directive'
-
-declare module 'mdast-util-directive' {
-  interface ContainerDirectiveData {
-    vlCellHeadingDepth?: number
-    vlParentHeadingDepth?: number
-  }
-}
 
 export type MarkdownRendererScope = 'blocks' | 'field'
 

--- a/src/types/layoutToken.ts
+++ b/src/types/layoutToken.ts
@@ -1,0 +1,26 @@
+import type { Data } from 'unist'
+
+export type LayoutName = '2col' | '3col' | 'section'
+
+export type LayoutToken =
+  | {
+      action: 'close'
+      data?: Data
+      type: 'vlLayoutToken'
+    }
+  | {
+      action: 'closeGrid'
+      data?: Data
+      type: 'vlLayoutToken'
+    }
+  | {
+      action: 'closeSection'
+      data?: Data
+      type: 'vlLayoutToken'
+    }
+  | {
+      action: 'open'
+      data?: Data
+      name: LayoutName
+      type: 'vlLayoutToken'
+    }

--- a/src/types/mdast.d.ts
+++ b/src/types/mdast.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @import {} from 'mdast-util-directive'
+ */
+
+import 'mdast-util-directive'
+
+import type { LayoutToken } from './layoutToken'
+
+declare module 'mdast-util-directive' {
+  interface ContainerDirectiveData {
+    vlCellHeadingDepth?: number
+    vlParentHeadingDepth?: number
+  }
+}
+
+declare module 'mdast' {
+  interface RootContentMap {
+    vlLayoutToken: LayoutToken
+  }
+}


### PR DESCRIPTION
Closes #9
Closes #10

## Removes a class of “compiler-like” parsing bugs caused by directive leakage into code blocks.

This PR resolves two issues in the Markdown rendering pipeline:

* **#9** — Directive tokens (`:::section`, etc.) being incorrectly processed inside fenced code blocks
* **#10** — Legacy code block config options lingering in `MarkdownBlock` params

---

## Changes

### 🔧 Directive parsing (fixes #9)

* Removed sentinel-based handling of layout directives
* Replaced with direct directive parsing at the remark layer
* Ensures directives are only interpreted in actual Markdown content—not inside fenced code blocks

**Result:**

* Code blocks now render *exactly as written*
* Eliminates directive leakage into code rendering
* Simplifies parsing logic significantly (no more sentinel indirection)

---

### 🧱 Code block config cleanup (fixes #10)

* Removed deprecated / pre-v1 fields:

  * `highlightLines`
  * `prettyCodeBlocks`
* Consolidated behavior under:

  * `enhancedCodeBlocks`

**Result:**

* Cleaner, single-path rendering model
* No more conflicting or overlapping flags
* Matches actual renderer behavior

---

### ⚠️ Breaking Changes (minor)

* `MarkdownBlock` code block config has been simplified
* Any usage of:

  * `highlightLines`
  * `prettyCodeBlocks`
    should be removed in favor of:
  * `enhancedCodeBlocks`

This is unlikely to affect most users unless they were heavily customizing code block behavior.

---

### 🧠 Rendering pipeline improvements

* Fixed empty-line handling in Shiki output
* Preserved line numbers on blank lines
* Normalized line layout without breaking formatting
* Resolved malformed inline style edge cases

---

### 📦 Advanced field exports

Exposed internal field builders under an advanced surface for composability:

```ts
export { vlMdCodeBlockConfig } from '../field/CodeBlockConfig/config.js'
export { vlMdConfig } from '../field/Config/config.js'
export { vlMdTailwindField } from '../field/Tailwind/config.js'
```

These are intended for:

* custom block implementations
* advanced admin configuration
* extending the Markdown system beyond defaults

---

## Summary

* Fixed directive parsing at the root (no more code block corruption)
* Simplified config surface to match actual behavior
* Improved Shiki rendering consistency
* Exposed advanced field APIs for extension