### PR TITLE
img.shields.io Badge Directives

### DIFF
--- a/.agents/skills/payload-markdown-docs/reference/payload-markdown-directives.md
+++ b/.agents/skills/payload-markdown-docs/reference/payload-markdown-directives.md
@@ -67,11 +67,57 @@ Render docs without turning them into Pages.
 
 Use cards for overview pages and choice sets.
 
+## Buttons
+
+```markdown
+:::buttons{align="left" stack="mobile" gap="md"}
+::button[Read Docs]{href="/getting-started" variant="primary"}
+::button[GitHub]{href="https://github.com/valkyrianlabs" variant="secondary" newTab=true}
+:::
+```
+
+Use buttons for clear calls to action. `::button` is a leaf directive and should include `href`.
+
+## Badges
+
+```markdown
+:::badges{
+  align="left"
+  gap="md"
+  wrap=true
+}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+::badge[build]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+}
+:::
+```
+
+Use `::badge` for individual `img.shields.io` badges and `:::badges` to group them. Prefer curated resolvers:
+
+- `type="static"` with `label`, `message`, and `color`
+- `type="npm"` with `target="version"`, `target="downloads"`, or `target="license"` and `package`
+- `type="github" target="workflow"` with `repo` and `workflow`
+- `type="github"` with `target="release"`, `target="license"`, or `target="stars"` and `repo`
+- `type="debian" target="version"` with `package`
+- `type="apt"` as an alias for `type="debian"`
+
+Use `path` only for uncovered Shields paths and `src` only for full `https://img.shields.io` URLs.
+
 ## Gotchas
 
 - Do not invent directive names.
 - Keep blank lines around nested directive content.
 - Use `:::steps` for procedures.
 - Use `:::cards` for overview grids.
+- Use `::badge` and `:::badges` for Shields badges.
 - Use `:::callout` for warnings, tips, and notes.
 - Prefer root-relative docs links in directive attributes, such as `href="/workflow/signed-push"`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,8 +231,5 @@ jobs:
           pnpm exec payload-markdown-docs push \
             --endpoint "https://valkyrianlabs.com/api/documentation/sync" \
             --source payload-markdown \
-            --repository "$GITHUB_REPOSITORY" \
-            --branch "$GITHUB_REF_NAME" \
-            --commit "$GITHUB_SHA" \
             --github-oidc \
             --publish

--- a/dev/blocks/RenderBlocks.tsx
+++ b/dev/blocks/RenderBlocks.tsx
@@ -1,8 +1,8 @@
-import { MarkdownBlockComponent } from '@valkyrianlabs/payload-markdown/server'
 import React, { Fragment } from 'react'
 
 import type { Page } from '../payload-types.ts'
 
+import { MarkdownBlockComponent } from '../../src/blocks/MarkdownBlock/Component.tsx'
 import { ArchiveBlock } from './ArchiveBlock/Component.tsx'
 
 const blockComponents = {

--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -549,6 +549,8 @@ describe('layout directive registry', () => {
       'cell',
       'button',
       'buttons',
+      'badge',
+      'badges',
       'callout',
       'details',
       'toc',
@@ -577,6 +579,13 @@ describe('layout directive registry', () => {
     })
     expect(layoutDirectiveRegistry.parseMarkdownLine(':::buttons{align="center"}')).toMatchObject({
       name: 'buttons',
+      action: 'open',
+      attributes: {
+        align: 'center',
+      },
+    })
+    expect(layoutDirectiveRegistry.parseMarkdownLine(':::badges{align="center"}')).toMatchObject({
+      name: 'badges',
       action: 'open',
       attributes: {
         align: 'center',
@@ -703,9 +712,10 @@ describe('layout directive registry', () => {
     expect(countSyntaxNodes(markdown, 'DirectiveLine')).toBe(2)
   })
 
-  it('highlights leaf button directives separately from container directives', () => {
+  it('highlights leaf directives separately from container directives', () => {
     const markdown = [
       '::button[Home]{href="/home"}',
+      '::badge[npm]{type="npm" target="version" package="payload"}',
       '',
       ':::buttons',
       '::button[Docs]{href="/docs"}',
@@ -717,7 +727,7 @@ describe('layout directive registry', () => {
       'ratio: 3:2',
     ].join('\n')
 
-    expect(countSyntaxNodes(markdown, 'LeafDirectiveLine')).toBe(2)
+    expect(countSyntaxNodes(markdown, 'LeafDirectiveLine')).toBe(3)
     expect(countSyntaxNodes(markdown, 'DirectiveLine')).toBe(2)
   })
 
@@ -816,6 +826,8 @@ Ignored body.
       'cell',
       'button',
       'buttons',
+      'badge',
+      'badges',
       'callout',
       'details',
       'toc',
@@ -837,6 +849,8 @@ Ignored body.
       '::button_icon',
       '::button_full',
       ':::buttons',
+      '::badge',
+      ':::badges',
       ':::callout',
       ':::details',
       ':::toc',
@@ -871,6 +885,7 @@ Ignored body.
 
     expect(snippets.some((snippet) => snippet.includes('${Content}'))).toBe(true)
     expect(snippets.some((snippet) => snippet.includes('::button[${Label}]'))).toBe(true)
+    expect(snippets.some((snippet) => snippet.includes('::badge[${npm version}]'))).toBe(true)
     expect(snippets.some((snippet) => snippet.includes('${Step title}'))).toBe(true)
     expect(snippets.some((snippet) => snippet.includes(':::card[${Title}]'))).toBe(true)
     expect(snippets.some((snippet) => snippet.includes(':::tabs{'))).toBe(true)
@@ -886,6 +901,10 @@ Ignored body.
       .toEqual(expect.arrayContaining(['ariaLabel', 'href', 'icon', 'iconPosition', 'newTab', 'size', 'variant']))
     expect(getDirectiveAttributeCompletionOptions('buttons').map((completion) => completion.label))
       .toEqual(expect.arrayContaining(['align', 'gap', 'stack']))
+    expect(getDirectiveAttributeCompletionOptions('badge').map((completion) => completion.label))
+      .toEqual(expect.arrayContaining(['href', 'newTab', 'package', 'path', 'src', 'target', 'type']))
+    expect(getDirectiveAttributeCompletionOptions('badges').map((completion) => completion.label))
+      .toEqual(expect.arrayContaining(['align', 'gap', 'wrap']))
     expect(getDirectiveAttributeCompletionOptions('steps').map((completion) => completion.label))
       .toEqual(expect.arrayContaining(['columns', 'layout', 'numbered', 'stepTheme', 'theme', 'variant']))
     expect(getDirectiveAttributeCompletionOptions('tabs').map((completion) => completion.label))
@@ -919,6 +938,16 @@ Ignored body.
       .toEqual(['mobile', 'always', 'never'])
     expect(getDirectiveThemeValueCompletionOptions('buttons', 'gap').map((completion) => completion.label))
       .toEqual(['sm', 'md', 'lg'])
+    expect(getDirectiveThemeValueCompletionOptions('badge', 'type').map((completion) => completion.label))
+      .toEqual(['static', 'npm', 'github', 'debian', 'apt'])
+    expect(getDirectiveThemeValueCompletionOptions('badge', 'target').map((completion) => completion.label))
+      .toEqual(['version', 'downloads', 'license', 'workflow', 'release', 'stars'])
+    expect(getDirectiveThemeValueCompletionOptions('badge', 'interval').map((completion) => completion.label))
+      .toEqual(['dw', 'dm', 'dy', 'dt'])
+    expect(getDirectiveThemeValueCompletionOptions('badge', 'newTab').map((completion) => completion.label))
+      .toEqual(['true', 'false'])
+    expect(getDirectiveThemeValueCompletionOptions('badges', 'wrap').map((completion) => completion.label))
+      .toEqual(['true', 'false'])
     expect(getDirectiveThemeValueCompletionOptions('steps', 'stepTheme').map((completion) => completion.label))
       .toEqual(expect.arrayContaining(['default', 'cyan', 'glass']))
     expect(getDirectiveThemeValueCompletionOptions('steps', 'layout').map((completion) => completion.label))
@@ -1005,10 +1034,10 @@ Image ratio: 3:2.
   })
 
   it('leaves unknown leaf directives as markdown text with a diagnostic', async () => {
-    const result = await compileMarkdown('::badge[Beta]{tone="info"}')
+    const result = await compileMarkdown('::pill[Beta]{tone="info"}')
 
-    expect(hasWarning(result.warnings, 'Unknown directive "badge".')).toBe(true)
-    expect(result.html).toContain('::badge[Beta]{tone="info"}')
+    expect(hasWarning(result.warnings, 'Unknown directive "pill".')).toBe(true)
+    expect(result.html).toContain('::pill[Beta]{tone="info"}')
     expect(countDirective(result.html, 'button')).toBe(0)
   })
 
@@ -1183,6 +1212,171 @@ Check credentials.
     expect(result.html).toContain('pmd-buttons--align-left')
     expect(result.html).toContain('pmd-buttons--stack-mobile')
     expect(result.html).toContain('pmd-buttons--gap-md')
+  })
+
+  it('renders badges wrapper alignment gap and wrap classes', async () => {
+    const result = await compileMarkdown(`
+:::badges{align="center" gap="lg" wrap=false}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+}
+:::
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(countDirective(result.html, 'badges')).toBe(1)
+    expect(countDirective(result.html, 'badge')).toBe(1)
+    expect(result.html).toContain('pmd-badges--align-center')
+    expect(result.html).toContain('pmd-badges--gap-lg')
+    expect(result.html).toContain('pmd-badges--wrap-false')
+    expect(result.html).toContain('pmd-badge')
+  })
+
+  it('renders npm version downloads and license badge URLs', async () => {
+    const result = await compileMarkdown(`
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+}
+::badge[npm downloads]{
+  type="npm"
+  target="downloads"
+  package="@valkyrianlabs/payload-markdown"
+}
+::badge[npm license]{
+  type="npm"
+  target="license"
+  package="@valkyrianlabs/payload-markdown"
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain('https://img.shields.io/npm/v/%40valkyrianlabs/payload-markdown')
+    expect(result.html).toContain('https://img.shields.io/npm/dw/%40valkyrianlabs/payload-markdown')
+    expect(result.html).toContain('https://img.shields.io/npm/l/%40valkyrianlabs/payload-markdown')
+  })
+
+  it('renders GitHub workflow badge URLs', async () => {
+    const result = await compileMarkdown(`
+::badge[build]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain(
+      'https://img.shields.io/github/actions/workflow/status/valkyrianlabs/payload-markdown/deploy.yml',
+    )
+  })
+
+  it('renders Debian and APT badge URLs', async () => {
+    const result = await compileMarkdown(`
+::badge[debian]{
+  type="debian"
+  target="version"
+  package="curl"
+}
+::badge[apt]{
+  type="apt"
+  target="version"
+  package="git"
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain('https://img.shields.io/debian/v/curl')
+    expect(result.html).toContain('https://img.shields.io/debian/v/git')
+  })
+
+  it('renders static badge URLs', async () => {
+    const result = await compileMarkdown(`
+::badge[docs]{
+  type="static"
+  label="docs"
+  message="ready"
+  color="blue"
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain('https://img.shields.io/badge/docs-ready-blue')
+  })
+
+  it('renders Shields path escape hatch URLs with encoded query attributes', async () => {
+    const result = await compileMarkdown(`
+::badge[coverage]{
+  path="badge/coverage-95-brightgreen"
+  style="flat-square"
+  labelColor="111"
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain('https://img.shields.io/badge/coverage-95-brightgreen')
+    expect(result.html).toContain('style=flat-square')
+    expect(result.html).toContain('labelColor=111')
+  })
+
+  it('validates Shields src escape hatch host', async () => {
+    const valid = await compileMarkdown(
+      '::badge[custom]{src="https://img.shields.io/badge/custom-ok-blue"}',
+    )
+    const invalid = await compileMarkdown(
+      '::badge[custom]{src="https://example.com/badge/custom-ok-blue"}',
+    )
+
+    expect(valid.warnings).toEqual([])
+    expect(valid.html).toContain('https://img.shields.io/badge/custom-ok-blue')
+    expect(hasWarning(invalid.warnings, 'src must use https://img.shields.io/')).toBe(true)
+    expect(countDirective(invalid.html, 'badge')).toBe(0)
+  })
+
+  it('renders href and new-tab badge anchor behavior', async () => {
+    const result = await compileMarkdown(`
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+  newTab=true
+}
+`)
+
+    expect(result.warnings).toEqual([])
+    expect(result.html).toContain('<a')
+    expect(result.html).toContain('data-directive="badge"')
+    expect(result.html).toContain('href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"')
+    expect(result.html).toContain('target="_blank"')
+    expect(result.html).toContain('rel="noopener noreferrer"')
+    expect(result.html).toContain('<img')
+    expect(result.html).not.toContain('link=')
+  })
+
+  it('emits diagnostics for invalid badge attrs without crashing', async () => {
+    const missingPackage = await compileMarkdown('::badge[npm]{type="npm" target="version"}')
+    const missingWorkflow = await compileMarkdown(
+      '::badge[build]{type="github" target="workflow" repo="valkyrianlabs/payload-markdown"}',
+    )
+    const invalidWrapper = await compileMarkdown(`
+:::badges{align="middle" gap="huge" wrap="maybe"}
+::badge[npm]{type="npm" target="version" package="payload"}
+:::
+`)
+
+    expect(hasWarning(missingPackage.warnings, 'requires package for type="npm"')).toBe(true)
+    expect(hasWarning(missingWorkflow.warnings, 'requires workflow')).toBe(true)
+    expect(hasWarning(invalidWrapper.warnings, 'Invalid badges align "middle"')).toBe(true)
+    expect(hasWarning(invalidWrapper.warnings, 'Invalid badges gap "huge"')).toBe(true)
+    expect(hasWarning(invalidWrapper.warnings, 'Invalid badges wrap "maybe"')).toBe(true)
+    expect(invalidWrapper.html).toContain('pmd-badges--align-left')
+    expect(invalidWrapper.html).toContain('pmd-badges--gap-md')
+    expect(invalidWrapper.html).toContain('pmd-badges--wrap-true')
   })
 
   it('renders cards with default columns and multiple card children', async () => {
@@ -2438,6 +2632,10 @@ Body.
 
 ::button[]{href="/settings" icon="@brand/github"}
 
+::badge[Broken]{type="github" target="workflow" repo="valkyrianlabs/payload-markdown"}
+
+::not-leaf[Broken]
+
 :::steps {mode="bad" variant="timeline" layout="diagonal" columns="wide" numbered="maybe"}
 ### Step
 Body.
@@ -2478,6 +2676,8 @@ Standalone.
       'Directive "button" requires an href attribute.',
       'Malformed icon ref "bad/ref". Expected "@pack/name".',
       'Icon-only button requires an ariaLabel attribute.',
+      'Directive "badge" requires workflow for type="github" target="workflow".',
+      'Unknown directive "not-leaf".',
       'Unknown attribute "mode" on "steps".',
       'Unsupported steps variant "timeline". Falling back to "default".',
       'Unsupported steps layout "diagonal". Falling back to "stack".',

--- a/dev/next.config.mjs
+++ b/dev/next.config.mjs
@@ -6,6 +6,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  allowedDevOrigins: ['10.0.0.11'],
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],

--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -238,10 +238,6 @@ export interface MarkdownBlock {
        */
       size?: ('lg' | 'md' | 'sm') | null;
       /**
-       * Whether to center the block content within its wrapper.
-       */
-      centered?: boolean | null;
-      /**
        * Whether to apply horizontal gutter padding to the block wrapper.
        */
       enableGutter?: boolean | null;
@@ -333,11 +329,7 @@ export interface MarkdownBlock {
         /**
          * Whether to apply the plugin's enhanced code block formatting. When enabled, the renderer normalizes Shiki output for better integration with markdown prose styling. This includes adjustments such as background removal, spacing cleanup, line layout normalization, and other structural fixes needed for features like line numbers and consistent empty-line rendering. Set this to false if you want to preserve raw Shiki block styling as much as possible.
          */
-        prettyCodeBlocks?: boolean | null;
-        /**
-         * Whether to enable line highlighting for the code block. When enabled, you can specify lines to highlight by including a line number list in the code block's language declaration. For example, a declaration of "js{1,4-5}" would highlight lines 1, 4, and 5 in the block.
-         */
-        highlightLines?: boolean | null;
+        enhancedCodeBlocks?: boolean | null;
       };
     };
   };
@@ -611,7 +603,6 @@ export interface MarkdownBlockSelect<T extends boolean = true> {
               columnClassName?: T;
               variant?: T;
               size?: T;
-              centered?: T;
               enableGutter?: T;
               fullBleedCode?: T;
               mutedHeadings?: T;
@@ -620,8 +611,7 @@ export interface MarkdownBlockSelect<T extends boolean = true> {
                 | {
                     theme?: T;
                     showLineNumbers?: T;
-                    prettyCodeBlocks?: T;
-                    highlightLines?: T;
+                    enhancedCodeBlocks?: T;
                   };
             };
       };

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -1,12 +1,12 @@
 import { postgresAdapter } from '@payloadcms/db-postgres'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
-import { DEFAULT_CODE_LANGS, payloadMarkdown } from '@valkyrianlabs/payload-markdown'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import path from 'path'
 import { buildConfig } from 'payload'
 import sharp from 'sharp'
 import { fileURLToPath } from 'url'
 
+import { DEFAULT_CODE_LANGS, payloadMarkdown } from '../dist'
 import { Archive } from './blocks/ArchiveBlock/config.ts'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -10,20 +10,33 @@ tags:
 
 # Payload Markdown
 
-<span class="flex flex-row gap-x-3 [&_img]:my-0">
-  <a href="https://github.com/valkyrianlabs/payload-markdown/actions">
-    <img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/valkyrianlabs/payload-markdown/deploy.yml">
-  </a>
-  <a href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown">
-    <img alt="npm" src="https://img.shields.io/npm/v/@valkyrianlabs/payload-markdown">
-  </a>
-  <a href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown">
-    <img alt="npm downloads" src="https://img.shields.io/npm/dw/@valkyrianlabs/payload-markdown">
-  </a>
-  <a href="https://github.com/valkyrianlabs/payload-markdown?tab=MIT-1-ov-file">
-    <img alt="license" src="https://img.shields.io/npm/l/@valkyrianlabs/payload-markdown">
-  </a>
-</span>
+:::badges
+::badge[GitHub Workflow Status]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+  href="https://github.com/valkyrianlabs/payload-markdown/actions"
+}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+::badge[npm downloads]{
+  type="npm"
+  target="downloads"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+::badge[license]{
+  type="npm"
+  target="license"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://github.com/valkyrianlabs/payload-markdown?tab=MIT-1-ov-file"
+}
+:::
 
 `@valkyrianlabs/payload-markdown` adds portable Markdown authoring to Payload CMS. It provides a CodeMirror-backed admin field, an optional reusable Payload block, server-rendered Markdown output, Shiki code highlighting, heading anchors, GFM support, and registry-backed content directives.
 
@@ -56,7 +69,7 @@ Use the server renderer for Markdown fields and the block component for `vlMdBlo
   eyebrow="Shape"
   href="/directives"
 }
-Use readable directives for callouts, details, TOCs, steps, cards, buttons, tabs, sections, columns, and cells.
+Use readable directives for callouts, details, TOCs, steps, cards, buttons, badges, tabs, sections, columns, and cells.
 :::
 
 :::

--- a/docs/authoring/editor.md
+++ b/docs/authoring/editor.md
@@ -31,10 +31,11 @@ Typing or invoking completion around `:::` offers public directives from the dir
 - `:::cards`
 - `:::card`
 - `:::buttons`
+- `:::badges`
 - `:::tabs`
 - `:::tab`
 
-Typing or invoking completion around `::button` offers the leaf button directive and its attributes.
+Typing or invoking completion around `::button` or `::badge` offers the leaf directive and its attributes.
 
 Button completion may also show shortcut labels such as `::button_icon` and `::button_full`. These are autocomplete variants only. Selecting them inserts canonical `::button[...]` Markdown; `::button_icon` and `::button_full` are not valid directive names in source.
 
@@ -110,6 +111,16 @@ Button snippets use the leaf directive form:
 }
 ```
 
+Badge snippets use the same leaf directive form:
+
+```md
+::badge[npm version]{
+  type="npm"
+  target="version"
+  package="package-name"
+}
+```
+
 Expanded multiline attributes are preferred for readability:
 
 ```md
@@ -129,7 +140,7 @@ If both `[Label]` and `title` are present, the renderer uses `[Label]`. Matching
 
 Directive highlighting distinguishes supported pieces where the active theme can style them:
 
-- leaf directives such as `::button`
+- leaf directives such as `::button` and `::badge`
 - container directives such as `:::card`
 - directive labels such as `[Fast Setup]`
 - argument names such as `href=`
@@ -207,6 +218,7 @@ The editor provides lightweight, non-fatal directive diagnostics for issues such
 - invalid steps variant, layout, columns, or numbered value
 - invalid cards columns
 - invalid tabs defaults or duplicate tab values
+- invalid badge types, targets, or required Shields attributes
 - unknown theme, `cardTheme`, `cellTheme`, `stepTheme`, or `tabTheme`
 - obvious unclosed directives
 

--- a/docs/directives/badges.md
+++ b/docs/directives/badges.md
@@ -1,0 +1,135 @@
+---
+title: Badges
+navTitle: Badges
+description: Render img.shields.io badges with curated directive resolvers and strict Shields escape hatches.
+order: 257
+status: published
+tags:
+  - directives
+  - badges
+---
+
+# Badges
+
+Use `::badge` leaf directives for individual Shields images and `:::badges` to group them.
+
+```md
+:::badges
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+:::
+```
+
+`::badge` renders an `img` from `https://img.shields.io`. When `href` is present, the renderer wraps the image in an anchor. Click behavior uses that anchor wrapper; the directive does not use Shields' `link` query parameter.
+
+## `::badge`
+
+Common attributes:
+
+- `[Label]`: default image `alt` text
+- `alt`: overrides the label-derived image alt text
+- `href`: optional link target
+- `newTab`: adds `target="_blank"` and `rel="noopener noreferrer"` when `true`
+- `style`, `logo`, `logoColor`, `logoSize`, `label`, `labelColor`, `color`, and `cacheSeconds`: passed through to Shields as encoded query attributes
+
+Curated resolvers:
+
+- `type="static"` with `label`, `message`, and `color`
+- `type="npm"` with `target="version"`, `target="downloads"`, or `target="license"` and `package`
+- `type="npm" target="downloads"` also accepts `interval`; default is `dw`
+- `type="github" target="workflow"` with `repo` and `workflow`
+- `type="github"` with `target="release"`, `target="license"`, or `target="stars"` and `repo`
+- `type="debian" target="version"` with `package`
+- `type="apt"` is an alias for `type="debian"`
+
+```md
+::badge[build]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+  href="https://github.com/valkyrianlabs/payload-markdown/actions"
+}
+```
+
+```md
+::badge[downloads]{
+  type="npm"
+  target="downloads"
+  package="@valkyrianlabs/payload-markdown"
+  interval="dm"
+}
+```
+
+```md
+::badge[debian]{
+  type="debian"
+  target="version"
+  package="curl"
+}
+```
+
+```md
+::badge[static]{
+  type="static"
+  label="docs"
+  message="ready"
+  color="0ea5e9"
+}
+```
+
+## Escape Hatches
+
+Use `path` for a Shields path that is not covered by the curated resolver map:
+
+```md
+::badge[coverage]{
+  path="badge/coverage-95%25-brightgreen"
+  style="flat-square"
+}
+```
+
+Use `src` only for full Shields URLs. The renderer rejects non-`https://img.shields.io` hosts.
+
+```md
+::badge[custom]{
+  src="https://img.shields.io/badge/custom-badge-blue"
+}
+```
+
+## `:::badges`
+
+Attributes:
+
+- `align`: `left`, `center`, or `right`
+- `gap`: `sm`, `md`, or `lg`
+- `wrap`: `true` or `false`
+
+Defaults:
+
+- `align="left"`
+- `gap="md"`
+- `wrap="true"`
+
+```md
+:::badges{
+  align="center"
+  gap="md"
+  wrap=true
+}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+}
+::badge[license]{
+  type="npm"
+  target="license"
+  package="@valkyrianlabs/payload-markdown"
+}
+:::
+```

--- a/docs/directives/index.md
+++ b/docs/directives/index.md
@@ -10,7 +10,7 @@ tags:
 
 # Directives
 
-Directives are Markdown primitives powered by the plugin directive registry. They keep content portable while giving the renderer enough structure for components such as callouts, details, tables of contents, steps, cards, buttons, tabs, sections, columns, and cells.
+Directives are Markdown primitives powered by the plugin directive registry. They keep content portable while giving the renderer enough structure for components such as callouts, details, tables of contents, steps, cards, buttons, badges, tabs, sections, columns, and cells.
 
 :::toc[On this page]{depth="3" theme="compact"}
 :::
@@ -25,6 +25,8 @@ Directives are Markdown primitives powered by the plugin directive registry. The
 - `:::card`
 - `::button`
 - `:::buttons`
+- `::badge`
+- `:::badges`
 - `:::tabs`
 - `:::tab`
 - `:::section`
@@ -140,6 +142,10 @@ Card grids and standalone card content.
 
 :::card[Buttons]{href="/directives/buttons"}
 Link buttons and grouped primary links with local SVG icons.
+:::
+
+:::card[Badges]{href="/directives/badges"}
+img.shields.io badges with curated resolvers and strict Shields escape hatches.
 :::
 
 :::card[Tabs]{href="/directives/tabs"}

--- a/docs/index.ai.yml
+++ b/docs/index.ai.yml
@@ -35,6 +35,7 @@ order:
   - ./directives/steps.md
   - ./directives/cards.md
   - ./directives/buttons.md
+  - ./directives/badges.md
   - ./directives/tabs.md
   - ./directives/layout.md
   - ./authoring/index.md

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -204,6 +204,8 @@ Layout directives:
 
 Static directives:
 
+- `badge`
+- `badges`
 - `button`
 - `buttons`
 - `callout`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valkyrianlabs/payload-markdown",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Structured Markdown editing and rendering for Payload CMS with CodeMirror, Shiki, directives, themes, and server-first output.",
   "repository": {
     "url": "https://github.com/valkyrianlabs/payload-markdown"

--- a/skills/payload-markdown/claude/SKILL.md
+++ b/skills/payload-markdown/claude/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: payload-markdown
-description: Write elegant automated documentation with @valkyrianlabs/payload-markdown. Use when authoring, rewriting, auditing, or structuring docs with Payload Markdown directives, theme names, cards, callouts, steps, tabs, TOCs, buttons, and layout primitives.
+description: Write elegant automated documentation with @valkyrianlabs/payload-markdown. Use when authoring, rewriting, auditing, or structuring docs with Payload Markdown directives, theme names, cards, callouts, steps, tabs, TOCs, buttons, badges, and layout primitives.
 ---
 
 # Payload Markdown
@@ -34,6 +34,7 @@ This package stores the Claude variant at `skills/payload-markdown/claude`. When
 - Use `:::callout` for important notes, warnings, tips, and migration hazards.
 - Use `:::steps` for setup, tutorials, and workflows.
 - Use `:::cards` and `:::card` for page maps, feature groups, related links, and summary grids.
+- Use `::badge` and `:::badges` for Shields badges when package, build, release, license, or status metadata helps orient the page.
 - Use `:::tabs` only for truly parallel alternatives such as package managers or framework variants.
 - Use `:::details` for optional caveats, migration notes, or advanced branches.
 - Use `:::section`, `:::2col`, `:::3col`, and `:::cell` sparingly for dense landing-style docs sections.

--- a/skills/payload-markdown/claude/reference/payload-markdown-directives.md
+++ b/skills/payload-markdown/claude/reference/payload-markdown-directives.md
@@ -31,6 +31,8 @@ Install, configure, ship.
 - `:::card`
 - `::button`
 - `:::buttons`
+- `::badge`
+- `:::badges`
 - `:::tabs`
 - `:::tab`
 - `:::section`
@@ -183,6 +185,60 @@ Use button links for clear actions. Do not use snippet-only names such as `::but
 :::buttons{align="center" stack="mobile" gap="md"}
 ::button[Read Docs]{href="/getting-started" variant="primary"}
 ::button[GitHub]{href="https://github.com/valkyrianlabs" variant="secondary" newTab=true}
+:::
+```
+
+## Badges
+
+Use badges for compact package, build, release, license, download, or status metadata. `::badge` renders an image from `https://img.shields.io`. When `href` is present, the renderer wraps the image in an anchor instead of using Shields' `link` query parameter.
+
+`::badge` common attributes:
+
+- `[Label]`: default image `alt` text
+- `alt`: overrides label-derived image alt text
+- `href`: optional link target
+- `newTab`: opens the anchor in a new tab
+- `style`, `logo`, `logoColor`, `logoSize`, `label`, `labelColor`, `color`, and `cacheSeconds`: encoded Shields query attributes
+
+Curated resolvers:
+
+- `type="static"` with `label`, `message`, and `color`
+- `type="npm"` with `target="version"`, `target="downloads"`, or `target="license"` and `package`
+- `type="npm" target="downloads"` accepts `interval`; default is `dw`
+- `type="github" target="workflow"` with `repo` and `workflow`
+- `type="github"` with `target="release"`, `target="license"`, or `target="stars"` and `repo`
+- `type="debian" target="version"` with `package`
+- `type="apt"` as an alias for `type="debian"`
+
+Escape hatches:
+
+- `path`: Shields path not covered by a curated resolver, such as `badge/coverage-95%25-brightgreen`
+- `src`: full `https://img.shields.io` URL only
+
+`:::badges` attributes:
+
+- `align`: `left`, `center`, or `right`
+- `gap`: `sm`, `md`, or `lg`
+- `wrap`: `true` or `false`
+
+```md
+:::badges{
+  align="center"
+  gap="md"
+  wrap=true
+}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+::badge[build]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+}
 :::
 ```
 

--- a/skills/payload-markdown/claude/reference/quality.md
+++ b/skills/payload-markdown/claude/reference/quality.md
@@ -26,6 +26,7 @@ Use this checklist before returning generated docs.
 - Multiline attributes are used for dense directives.
 - `linkScope="title"` is used for cards containing buttons or links.
 - Button directives include `href`.
+- Badge directives use a curated resolver, `path`, or a Shields `src`.
 - Icon-only buttons include `ariaLabel`.
 - Tabs have stable `value` attributes.
 

--- a/skills/payload-markdown/claude/scripts/check_payload_markdown_doc.py
+++ b/skills/payload-markdown/claude/scripts/check_payload_markdown_doc.py
@@ -15,6 +15,7 @@ CONTAINER_DIRECTIVES = {
     "cards",
     "card",
     "buttons",
+    "badges",
     "tabs",
     "tab",
     "section",
@@ -22,8 +23,15 @@ CONTAINER_DIRECTIVES = {
     "3col",
     "cell",
 }
-LEAF_DIRECTIVES = {"button"}
+LEAF_DIRECTIVES = {"button", "badge"}
 ALL_DIRECTIVES = CONTAINER_DIRECTIVES | LEAF_DIRECTIVES
+BADGE_TYPES = {"static", "npm", "github", "debian", "apt"}
+BADGE_TARGETS = {
+    "npm": {"version", "downloads", "license"},
+    "github": {"workflow", "release", "license", "stars"},
+    "debian": {"version"},
+    "apt": {"version"},
+}
 
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DIRECTIVE_RE = re.compile(r"^\s*::(?P<colons>:?)(?P<name>[A-Za-z0-9_-]+)\b(?P<rest>.*)$")
@@ -65,14 +73,29 @@ def parse_attrs(rest: str) -> dict[str, str]:
     return attrs
 
 
+def collect_attr_text(lines: list[tuple[int, str, bool]], start_index: int, rest: str) -> str:
+    if "{" not in rest or "}" in rest:
+        return rest
+
+    parts = [rest]
+    for _, next_line, in_fence in lines[start_index + 1 :]:
+        if in_fence:
+            break
+        parts.append(next_line)
+        if "}" in next_line:
+            break
+    return "\n".join(parts)
+
+
 def check_file(path: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     body = strip_frontmatter(text)
+    lines = list(iter_content_lines(body))
     warnings: list[str] = []
     h1_count = 0
     stack: list[tuple[str, int]] = []
 
-    for line_no, line, in_fence in iter_content_lines(body):
+    for index, (line_no, line, in_fence) in enumerate(lines):
         if in_fence:
             continue
 
@@ -117,9 +140,31 @@ def check_file(path: Path) -> list[str]:
         if name in CONTAINER_DIRECTIVES and not is_container:
             warnings.append(f"{path}:{line_no}: container directive should use three colons: {name}")
 
-        attrs = parse_attrs(rest)
+        attrs = parse_attrs(collect_attr_text(lines, index, rest))
         if name == "button" and "href" not in attrs:
             warnings.append(f"{path}:{line_no}: button directive should include href")
+        if name == "badge":
+            badge_type = attrs.get("type")
+            target = attrs.get("target")
+            src = attrs.get("src", "")
+            if "src" in attrs and not src.startswith("https://img.shields.io/"):
+                warnings.append(f"{path}:{line_no}: badge src must use https://img.shields.io")
+            if not badge_type and "path" not in attrs and "src" not in attrs:
+                warnings.append(f"{path}:{line_no}: badge directive should include type, path, or Shields src")
+            if badge_type and badge_type not in BADGE_TYPES:
+                warnings.append(f"{path}:{line_no}: unsupported badge type: {badge_type}")
+            if badge_type in BADGE_TARGETS and target not in BADGE_TARGETS[badge_type]:
+                warnings.append(f"{path}:{line_no}: unsupported badge target for {badge_type}: {target}")
+            if badge_type in {"npm", "debian", "apt"} and "package" not in attrs:
+                warnings.append(f"{path}:{line_no}: {badge_type} badge should include package")
+            if badge_type == "github" and "repo" not in attrs:
+                warnings.append(f"{path}:{line_no}: github badge should include repo")
+            if badge_type == "github" and target == "workflow" and "workflow" not in attrs:
+                warnings.append(f"{path}:{line_no}: github workflow badge should include workflow")
+            if badge_type == "static":
+                for required in ("label", "message", "color"):
+                    if required not in attrs:
+                        warnings.append(f"{path}:{line_no}: static badge should include {required}")
         if name == "tab" and "value" not in attrs:
             warnings.append(f"{path}:{line_no}: tab directive should include a stable value")
         if name == "card" and attrs.get("linkScope") == "full":

--- a/skills/payload-markdown/codex/SKILL.md
+++ b/skills/payload-markdown/codex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: payload-markdown
-description: Write elegant automated documentation with @valkyrianlabs/payload-markdown. Use when Codex needs to author, rewrite, audit, or structure docs using Payload Markdown directives, theme names, cards, callouts, steps, tabs, TOCs, buttons, and layout primitives.
+description: Write elegant automated documentation with @valkyrianlabs/payload-markdown. Use when Codex needs to author, rewrite, audit, or structure docs using Payload Markdown directives, theme names, cards, callouts, steps, tabs, TOCs, buttons, badges, and layout primitives.
 ---
 
 # Payload Markdown
@@ -34,6 +34,7 @@ This package stores the Codex variant at `skills/payload-markdown/codex`. When i
 - Use `:::callout` for important notes, warnings, tips, and migration hazards.
 - Use `:::steps` for setup, tutorials, and workflows.
 - Use `:::cards` and `:::card` for page maps, feature groups, related links, and summary grids.
+- Use `::badge` and `:::badges` for Shields badges when package, build, release, license, or status metadata helps orient the page.
 - Use `:::tabs` only for truly parallel alternatives such as package managers or framework variants.
 - Use `:::details` for optional caveats, migration notes, or advanced branches.
 - Use `:::section`, `:::2col`, `:::3col`, and `:::cell` sparingly for dense landing-style docs sections.

--- a/skills/payload-markdown/codex/reference/payload-markdown-directives.md
+++ b/skills/payload-markdown/codex/reference/payload-markdown-directives.md
@@ -31,6 +31,8 @@ Install, configure, ship.
 - `:::card`
 - `::button`
 - `:::buttons`
+- `::badge`
+- `:::badges`
 - `:::tabs`
 - `:::tab`
 - `:::section`
@@ -183,6 +185,60 @@ Use button links for clear actions. Do not use snippet-only names such as `::but
 :::buttons{align="center" stack="mobile" gap="md"}
 ::button[Read Docs]{href="/getting-started" variant="primary"}
 ::button[GitHub]{href="https://github.com/valkyrianlabs" variant="secondary" newTab=true}
+:::
+```
+
+## Badges
+
+Use badges for compact package, build, release, license, download, or status metadata. `::badge` renders an image from `https://img.shields.io`. When `href` is present, the renderer wraps the image in an anchor instead of using Shields' `link` query parameter.
+
+`::badge` common attributes:
+
+- `[Label]`: default image `alt` text
+- `alt`: overrides label-derived image alt text
+- `href`: optional link target
+- `newTab`: opens the anchor in a new tab
+- `style`, `logo`, `logoColor`, `logoSize`, `label`, `labelColor`, `color`, and `cacheSeconds`: encoded Shields query attributes
+
+Curated resolvers:
+
+- `type="static"` with `label`, `message`, and `color`
+- `type="npm"` with `target="version"`, `target="downloads"`, or `target="license"` and `package`
+- `type="npm" target="downloads"` accepts `interval`; default is `dw`
+- `type="github" target="workflow"` with `repo` and `workflow`
+- `type="github"` with `target="release"`, `target="license"`, or `target="stars"` and `repo`
+- `type="debian" target="version"` with `package`
+- `type="apt"` as an alias for `type="debian"`
+
+Escape hatches:
+
+- `path`: Shields path not covered by a curated resolver, such as `badge/coverage-95%25-brightgreen`
+- `src`: full `https://img.shields.io` URL only
+
+`:::badges` attributes:
+
+- `align`: `left`, `center`, or `right`
+- `gap`: `sm`, `md`, or `lg`
+- `wrap`: `true` or `false`
+
+```md
+:::badges{
+  align="center"
+  gap="md"
+  wrap=true
+}
+::badge[npm]{
+  type="npm"
+  target="version"
+  package="@valkyrianlabs/payload-markdown"
+  href="https://www.npmjs.com/package/@valkyrianlabs/payload-markdown"
+}
+::badge[build]{
+  type="github"
+  target="workflow"
+  repo="valkyrianlabs/payload-markdown"
+  workflow="deploy.yml"
+}
 :::
 ```
 

--- a/skills/payload-markdown/codex/reference/quality.md
+++ b/skills/payload-markdown/codex/reference/quality.md
@@ -26,6 +26,7 @@ Use this checklist before returning generated docs.
 - Multiline attributes are used for dense directives.
 - `linkScope="title"` is used for cards containing buttons or links.
 - Button directives include `href`.
+- Badge directives use a curated resolver, `path`, or a Shields `src`.
 - Icon-only buttons include `ariaLabel`.
 - Tabs have stable `value` attributes.
 

--- a/skills/payload-markdown/codex/scripts/check_payload_markdown_doc.py
+++ b/skills/payload-markdown/codex/scripts/check_payload_markdown_doc.py
@@ -15,6 +15,7 @@ CONTAINER_DIRECTIVES = {
     "cards",
     "card",
     "buttons",
+    "badges",
     "tabs",
     "tab",
     "section",
@@ -22,8 +23,15 @@ CONTAINER_DIRECTIVES = {
     "3col",
     "cell",
 }
-LEAF_DIRECTIVES = {"button"}
+LEAF_DIRECTIVES = {"button", "badge"}
 ALL_DIRECTIVES = CONTAINER_DIRECTIVES | LEAF_DIRECTIVES
+BADGE_TYPES = {"static", "npm", "github", "debian", "apt"}
+BADGE_TARGETS = {
+    "npm": {"version", "downloads", "license"},
+    "github": {"workflow", "release", "license", "stars"},
+    "debian": {"version"},
+    "apt": {"version"},
+}
 
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DIRECTIVE_RE = re.compile(r"^\s*::(?P<colons>:?)(?P<name>[A-Za-z0-9_-]+)\b(?P<rest>.*)$")
@@ -65,14 +73,29 @@ def parse_attrs(rest: str) -> dict[str, str]:
     return attrs
 
 
+def collect_attr_text(lines: list[tuple[int, str, bool]], start_index: int, rest: str) -> str:
+    if "{" not in rest or "}" in rest:
+        return rest
+
+    parts = [rest]
+    for _, next_line, in_fence in lines[start_index + 1 :]:
+        if in_fence:
+            break
+        parts.append(next_line)
+        if "}" in next_line:
+            break
+    return "\n".join(parts)
+
+
 def check_file(path: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     body = strip_frontmatter(text)
+    lines = list(iter_content_lines(body))
     warnings: list[str] = []
     h1_count = 0
     stack: list[tuple[str, int]] = []
 
-    for line_no, line, in_fence in iter_content_lines(body):
+    for index, (line_no, line, in_fence) in enumerate(lines):
         if in_fence:
             continue
 
@@ -117,9 +140,31 @@ def check_file(path: Path) -> list[str]:
         if name in CONTAINER_DIRECTIVES and not is_container:
             warnings.append(f"{path}:{line_no}: container directive should use three colons: {name}")
 
-        attrs = parse_attrs(rest)
+        attrs = parse_attrs(collect_attr_text(lines, index, rest))
         if name == "button" and "href" not in attrs:
             warnings.append(f"{path}:{line_no}: button directive should include href")
+        if name == "badge":
+            badge_type = attrs.get("type")
+            target = attrs.get("target")
+            src = attrs.get("src", "")
+            if "src" in attrs and not src.startswith("https://img.shields.io/"):
+                warnings.append(f"{path}:{line_no}: badge src must use https://img.shields.io")
+            if not badge_type and "path" not in attrs and "src" not in attrs:
+                warnings.append(f"{path}:{line_no}: badge directive should include type, path, or Shields src")
+            if badge_type and badge_type not in BADGE_TYPES:
+                warnings.append(f"{path}:{line_no}: unsupported badge type: {badge_type}")
+            if badge_type in BADGE_TARGETS and target not in BADGE_TARGETS[badge_type]:
+                warnings.append(f"{path}:{line_no}: unsupported badge target for {badge_type}: {target}")
+            if badge_type in {"npm", "debian", "apt"} and "package" not in attrs:
+                warnings.append(f"{path}:{line_no}: {badge_type} badge should include package")
+            if badge_type == "github" and "repo" not in attrs:
+                warnings.append(f"{path}:{line_no}: github badge should include repo")
+            if badge_type == "github" and target == "workflow" and "workflow" not in attrs:
+                warnings.append(f"{path}:{line_no}: github workflow badge should include workflow")
+            if badge_type == "static":
+                for required in ("label", "message", "color"):
+                    if required not in attrs:
+                        warnings.append(f"{path}:{line_no}: static badge should include {required}")
         if name == "tab" and "value" not in attrs:
             warnings.append(f"{path}:{line_no}: tab directive should include a stable value")
         if name == "card" and attrs.get("linkScope") == "full":

--- a/src/components/MarkdownRenderer/index.css
+++ b/src/components/MarkdownRenderer/index.css
@@ -216,4 +216,59 @@ pre.shiki.md-code-enhanced code span.md-line .md-empty-line {
   gap: 1rem;
 }
 
+.pmd-badges {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  vertical-align: middle;
+}
+
+.pmd-badges--align-left {
+  justify-content: flex-start;
+}
+
+.pmd-badges--align-center {
+  justify-content: center;
+}
+
+.pmd-badges--align-right {
+  justify-content: flex-end;
+}
+
+.pmd-badges--gap-sm {
+  gap: 0.5rem;
+}
+
+.pmd-badges--gap-md {
+  gap: 0.75rem;
+}
+
+.pmd-badges--gap-lg {
+  gap: 1rem;
+}
+
+.pmd-badges--wrap-true {
+  flex-wrap: wrap;
+}
+
+.pmd-badges--wrap-false {
+  flex-wrap: nowrap;
+}
+
+.pmd-badge-link {
+  display: inline-flex;
+  line-height: 0;
+  text-decoration: none;
+}
+
+.pmd-badge {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 /*# sourceMappingURL=index.css.map */

--- a/src/components/MarkdownRenderer/index.scss
+++ b/src/components/MarkdownRenderer/index.scss
@@ -239,3 +239,58 @@ pre.shiki.md-code-enhanced {
 .pmd-buttons--gap-lg {
   gap: 1rem;
 }
+
+.pmd-badges {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  vertical-align: middle;
+}
+
+.pmd-badges--align-left {
+  justify-content: flex-start;
+}
+
+.pmd-badges--align-center {
+  justify-content: center;
+}
+
+.pmd-badges--align-right {
+  justify-content: flex-end;
+}
+
+.pmd-badges--gap-sm {
+  gap: 0.5rem;
+}
+
+.pmd-badges--gap-md {
+  gap: 0.75rem;
+}
+
+.pmd-badges--gap-lg {
+  gap: 1rem;
+}
+
+.pmd-badges--wrap-true {
+  flex-wrap: wrap;
+}
+
+.pmd-badges--wrap-false {
+  flex-wrap: nowrap;
+}
+
+.pmd-badge-link {
+  display: inline-flex;
+  line-height: 0;
+  text-decoration: none;
+}
+
+.pmd-badge {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/src/core/plugins/remarkBadgeDirectives.ts
+++ b/src/core/plugins/remarkBadgeDirectives.ts
@@ -1,0 +1,245 @@
+import type { Paragraph, PhrasingContent, Root, RootContent, Text } from 'mdast'
+import type { LeafDirective } from 'mdast-util-directive'
+import type { Plugin } from 'unified'
+
+import { hasUnclosedDirectiveAttributeBlock } from '../../directives/attributes.js'
+import { parseLeafDirectiveLine } from '../../directives/leafSyntax.js'
+import { layoutDirectiveRegistry } from '../../directives/registry.js'
+import { resolveShieldsBadge } from '../../directives/shields.js'
+
+type MessageFile = {
+  message: (reason: string) => unknown
+}
+
+function isParagraph(node: RootContent): node is Paragraph {
+  return node.type === 'paragraph'
+}
+
+function isText(node: Paragraph['children'][number]): node is Text {
+  return node.type === 'text'
+}
+
+function makeText(value: string): Text {
+  return {
+    type: 'text',
+    value,
+  }
+}
+
+function splitParagraphLines(node: Paragraph): PhrasingContent[][] {
+  const lines: PhrasingContent[][] = [[]]
+  const currentLine = () => lines[lines.length - 1]
+
+  for (const child of node.children) {
+    if (!isText(child)) {
+      currentLine().push(child)
+      continue
+    }
+
+    const parts = child.value.split(/\r?\n/)
+
+    for (let index = 0; index < parts.length; ++index) {
+      if (index > 0) lines.push([])
+      if (parts[index]) currentLine().push(makeText(parts[index]))
+    }
+  }
+
+  return lines
+}
+
+function collectExpandedDirectiveText(
+  lines: PhrasingContent[][],
+  startIndex: number,
+): { endIndex: number; text: string } | null {
+  const firstText = getTextOnlyLine(lines[startIndex])
+
+  if (!firstText) return null
+  if (!hasUnclosedDirectiveAttributeBlock(firstText))
+    return {
+      endIndex: startIndex,
+      text: firstText,
+    }
+
+  let text = firstText
+
+  for (let index = startIndex + 1; index < lines.length; ++index) {
+    const nextText = getTextOnlyLine(lines[index])
+
+    if (nextText === null) break
+    if (nextText.trim().startsWith('::')) break
+
+    text += `\n${nextText}`
+
+    if (!hasUnclosedDirectiveAttributeBlock(text))
+      return {
+        endIndex: index,
+        text,
+      }
+  }
+
+  return {
+    endIndex: startIndex,
+    text: firstText,
+  }
+}
+
+function phrasingToText(node: PhrasingContent): null | string {
+  if (node.type === 'text') return node.value
+  if (node.type === 'inlineCode') return node.value
+  if ('children' in node && Array.isArray(node.children)) {
+    const values = node.children.map((child) => phrasingToText(child))
+
+    return values.every((value): value is string => typeof value === 'string')
+      ? values.join('')
+      : null
+  }
+
+  return null
+}
+
+function getTextOnlyLine(children: PhrasingContent[]): null | string {
+  const values = children.map((child) => phrasingToText(child))
+
+  if (!values.every((value): value is string => typeof value === 'string')) return null
+
+  return values.join('')
+}
+
+function appendParagraphLine(lines: PhrasingContent[][], children: PhrasingContent[]) {
+  if (lines.length > 0) lines.push([makeText('\n'), ...children])
+  else lines.push(children)
+}
+
+function flattenParagraphLines(lines: PhrasingContent[][]): PhrasingContent[] {
+  return lines.flat()
+}
+
+function getAttribute(attributes: Record<string, boolean | string>, name: string): string | undefined {
+  const value = attributes[name]
+
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function getBooleanAttribute(attributes: Record<string, boolean | string>, name: string): boolean {
+  const value = attributes[name]
+
+  if (value === true) return true
+  if (typeof value !== 'string') return false
+
+  return value === 'true'
+}
+
+function stringifyAttributes(attributes: Record<string, boolean | string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(attributes).map(([key, value]) => [key, String(value)]))
+}
+
+function makeBadgeImageProperties(src: string, alt: string, includeDirective: boolean) {
+  return {
+    alt,
+    className: ['pmd-badge'],
+    ...(includeDirective ? { dataDirective: 'badge' } : {}),
+    src,
+  }
+}
+
+function makeBadgeDirective(line: string, file: MessageFile): LeafDirective | undefined {
+  const parsed = parseLeafDirectiveLine(line, 'badge')
+  if (!parsed) return undefined
+
+  const definition = layoutDirectiveRegistry.get('badge')
+  const attributes = parsed.attributes
+  const label = parsed.label.trim()
+  const href = getAttribute(attributes, 'href')
+  const newTab = getBooleanAttribute(attributes, 'newTab')
+  const alt = getAttribute(attributes, 'alt') ?? label
+
+  for (const warning of parsed.warnings) file.message(warning)
+  for (const warning of definition?.validateAttributes?.({ name: 'badge', attributes }) ?? [])
+    file.message(warning)
+
+  const resolved = resolveShieldsBadge(attributes)
+
+  for (const warning of resolved.warnings) file.message(warning)
+  if (!resolved.src) return undefined
+
+  const imgProperties = makeBadgeImageProperties(resolved.src, alt, !href)
+
+  return {
+    name: 'badge',
+    type: 'leafDirective',
+    attributes: stringifyAttributes(attributes),
+    children: label ? [{ type: 'text', value: label }] : [],
+    data: href
+      ? {
+          hChildren: [
+            {
+              type: 'element' as const,
+              children: [],
+              properties: imgProperties,
+              tagName: 'img',
+            },
+          ],
+          hName: 'a',
+          hProperties: {
+            className: ['pmd-badge-link'],
+            dataDirective: 'badge',
+            href,
+            ...(newTab
+              ? {
+                  rel: 'noopener noreferrer',
+                  target: '_blank',
+                }
+              : {}),
+          },
+        }
+      : {
+          hName: 'img',
+          hProperties: imgProperties,
+        },
+  }
+}
+
+function splitParagraphBadgeDirectives(node: Paragraph, file: MessageFile): RootContent[] {
+  const out: RootContent[] = []
+  let paragraphLines: PhrasingContent[][] = []
+
+  const flushParagraph = () => {
+    const children = flattenParagraphLines(paragraphLines)
+
+    if (children.length > 0) out.push({ type: 'paragraph', children })
+
+    paragraphLines = []
+  }
+
+  const lines = splitParagraphLines(node)
+
+  for (let index = 0; index < lines.length; ++index) {
+    const lineChildren = lines[index]
+    const text = getTextOnlyLine(lineChildren)
+    const expanded = text ? collectExpandedDirectiveText(lines, index) : null
+    const badge = expanded ? makeBadgeDirective(expanded.text, file) : undefined
+
+    if (!badge) {
+      appendParagraphLine(paragraphLines, lineChildren)
+      continue
+    }
+
+    flushParagraph()
+    out.push(badge as RootContent)
+    index = expanded?.endIndex ?? index
+  }
+
+  flushParagraph()
+
+  return out.length > 0 ? out : [node]
+}
+
+export const remarkBadgeDirectives: Plugin<[], Root> = () => {
+  return (tree, file) => {
+    tree.children = tree.children.flatMap((node): RootContent[] => {
+      if (!isParagraph(node)) return [node]
+
+      return splitParagraphBadgeDirectives(node, file)
+    })
+  }
+}

--- a/src/core/plugins/remarkButtonDirectives.ts
+++ b/src/core/plugins/remarkButtonDirectives.ts
@@ -17,6 +17,8 @@ import {
 import { layoutDirectiveRegistry } from '../../directives/registry.js'
 import { normalizePayloadMarkdownIconRef } from '../../icons/refs.js'
 
+const SUPPORTED_LEAF_DIRECTIVE_NAMES = new Set(['badge', 'button'])
+
 type MessageFile = {
   message: (reason: string) => unknown
 }
@@ -274,7 +276,8 @@ function splitParagraphButtonDirectives(
 
     if (!button) {
       const leafName = text ? getLeafDirectiveName(text) : undefined
-      if (leafName && leafName !== 'button') file.message(`Unknown directive "${leafName}".`)
+      if (leafName && !SUPPORTED_LEAF_DIRECTIVE_NAMES.has(leafName))
+        file.message(`Unknown directive "${leafName}".`)
 
       appendParagraphLine(paragraphLines, lineChildren)
       continue

--- a/src/core/renderMarkdown.ts
+++ b/src/core/renderMarkdown.ts
@@ -19,6 +19,7 @@ import { codeToHtml } from './codeToHtml.js'
 import { rehypeApplyLayoutClasses } from './plugins/rehypeApplyLayoutClasses.js'
 import { rehypeResolveIcons } from './plugins/rehypeResolveIcons.js'
 import { rehypeStripAuthoredInlineStyles } from './plugins/rehypeStripAuthoredInlineStyles.js'
+import { remarkBadgeDirectives } from './plugins/remarkBadgeDirectives.js'
 import { remarkButtonDirectives } from './plugins/remarkButtonDirectives.js'
 import { remarkCompileLayouts } from './plugins/remarkCompileLayouts.js'
 import { remarkHeadingAnchorsAndToc } from './plugins/remarkHeadingAnchorsAndToc.js'
@@ -189,6 +190,7 @@ const sanitizeSchema: Schema = {
       'dataStack',
       'dataVariant',
       'dataVlLayout',
+      'dataWrap',
       'dataVlCellHeadingDepth',
       'hidden',
       'id',
@@ -218,8 +220,10 @@ const sanitizeSchema: Schema = {
     h6: [...getAttributeDefinitions(defaultSchema.attributes?.h6 ?? []), 'dataHeadingAnchor', 'id'],
     img: [
       ...getAttributeDefinitions(defaultSchema.attributes?.img ?? []),
-      'src',
       'alt',
+      'className',
+      'dataDirective',
+      'src',
       'title',
       'width',
       'height',
@@ -307,6 +311,7 @@ export async function compileMarkdown(
       .use(remarkGfm)
       .use(remarkLiftLayoutDirectives)
       .use(remarkButtonDirectives, config)
+      .use(remarkBadgeDirectives)
       .use(remarkCompileLayouts)
       .use(remarkLayoutDirectives)
       .use(remarkValidateDirectiveThemes, config)

--- a/src/directives/buttonSyntax.ts
+++ b/src/directives/buttonSyntax.ts
@@ -1,6 +1,6 @@
 import type { DirectiveAttributes } from './attributes.js'
 
-import { parseDirectiveAttributesDetailed } from './attributes.js'
+import { parseLeafDirectiveLine } from './leafSyntax.js'
 
 export type ParsedButtonDirectiveLine = {
   attributes: DirectiveAttributes
@@ -8,35 +8,6 @@ export type ParsedButtonDirectiveLine = {
   warnings: string[]
 }
 
-const BUTTON_LEAF_MARKER = '::button'
-
 export function parseButtonDirectiveLine(text: string): null | ParsedButtonDirectiveLine {
-  const trimmed = text.trim()
-  if (!trimmed.startsWith(BUTTON_LEAF_MARKER)) return null
-
-  let rest = trimmed.slice(BUTTON_LEAF_MARKER.length)
-  if (rest && !/^[\s[{]/.test(rest)) return null
-
-  rest = rest.trimStart()
-  let label = ''
-
-  if (rest.startsWith('[')) {
-    const labelEnd = rest.indexOf(']')
-    if (labelEnd < 0) return null
-
-    label = rest.slice(1, labelEnd)
-    rest = rest.slice(labelEnd + 1).trimStart()
-  }
-
-  const rawAttributes = rest
-  if (rawAttributes && (!rawAttributes.startsWith('{') || !rawAttributes.endsWith('}')))
-    return null
-
-  const parsedAttributes = parseDirectiveAttributesDetailed(rawAttributes)
-
-  return {
-    attributes: parsedAttributes.attributes,
-    label,
-    warnings: parsedAttributes.warnings,
-  }
+  return parseLeafDirectiveLine(text, 'button')
 }

--- a/src/directives/definitions/badge.ts
+++ b/src/directives/definitions/badge.ts
@@ -1,0 +1,60 @@
+import type { LayoutDirectiveDefinition } from '../types.js'
+
+import { getUnknownAttributeWarnings } from '../attributeDiagnostics.js'
+import { SHIELDS_BADGE_QUERY_ATTRIBUTES } from '../shields.js'
+
+export const BADGE_TYPES = ['static', 'npm', 'github', 'debian', 'apt'] as const
+export const BADGE_TARGETS = [
+  'version',
+  'downloads',
+  'license',
+  'workflow',
+  'release',
+  'stars',
+] as const
+export const BADGE_INTERVALS = ['dw', 'dm', 'dy', 'dt'] as const
+export const BADGE_STYLES = ['flat', 'flat-square', 'plastic', 'for-the-badge', 'social'] as const
+export const BADGE_ALLOWED_ATTRIBUTES = [
+  'alt',
+  'href',
+  'interval',
+  'message',
+  'newTab',
+  'package',
+  'path',
+  'repo',
+  'src',
+  'target',
+  'type',
+  'workflow',
+  ...SHIELDS_BADGE_QUERY_ATTRIBUTES,
+] as const
+
+export const badgeDirective: LayoutDirectiveDefinition = {
+  name: 'badge',
+  allowedAttributes: BADGE_ALLOWED_ATTRIBUTES,
+  attributeValues: {
+    type: BADGE_TYPES,
+    interval: BADGE_INTERVALS,
+    newTab: ['true', 'false'],
+    style: BADGE_STYLES,
+    target: BADGE_TARGETS,
+  },
+  defaultAttributes: {
+    newTab: 'false',
+  },
+  description: 'img.shields.io badge with curated resolvers and strict Shields escape hatches.',
+  editor: {
+    detail: 'Shields badge leaf directive',
+    label: '::badge',
+    snippet:
+      '::badge[${npm version}]{\n  type="${npm}"\n  target="${version}"\n  package="${package-name}"\n}\n${}',
+  },
+  kind: 'badge',
+  public: true,
+  supportsAttributes: true,
+  tagName: 'img',
+  validateAttributes({ attributes }) {
+    return getUnknownAttributeWarnings('badge', BADGE_ALLOWED_ATTRIBUTES, attributes)
+  },
+}

--- a/src/directives/definitions/badges.ts
+++ b/src/directives/definitions/badges.ts
@@ -1,0 +1,105 @@
+import type { LayoutDirectiveDefinition } from '../types.js'
+
+export const BADGES_ALIGNS = ['left', 'center', 'right'] as const
+export const BADGES_GAPS = ['sm', 'md', 'lg'] as const
+export const BADGES_WRAPS = ['true', 'false'] as const
+
+export const DEFAULT_BADGES_ALIGN = 'left'
+export const DEFAULT_BADGES_GAP = 'md'
+export const DEFAULT_BADGES_WRAP = 'true'
+
+type BadgesAlign = (typeof BADGES_ALIGNS)[number]
+type BadgesGap = (typeof BADGES_GAPS)[number]
+type BadgesWrap = (typeof BADGES_WRAPS)[number]
+
+function isBadgesAlign(value: unknown): value is BadgesAlign {
+  return typeof value === 'string' && BADGES_ALIGNS.includes(value as BadgesAlign)
+}
+
+function isBadgesGap(value: unknown): value is BadgesGap {
+  return typeof value === 'string' && BADGES_GAPS.includes(value as BadgesGap)
+}
+
+function isBadgesWrap(value: unknown): value is BadgesWrap {
+  return typeof value === 'string' && BADGES_WRAPS.includes(value as BadgesWrap)
+}
+
+export const badgesDirective: LayoutDirectiveDefinition = {
+  name: 'badges',
+  allowedAttributes: ['align', 'gap', 'wrap'],
+  applyHast(node, _config, { mergeClassNames }) {
+    const align =
+      typeof node.properties.dataAlign === 'string' && isBadgesAlign(node.properties.dataAlign)
+        ? node.properties.dataAlign
+        : DEFAULT_BADGES_ALIGN
+    const gap =
+      typeof node.properties.dataGap === 'string' && isBadgesGap(node.properties.dataGap)
+        ? node.properties.dataGap
+        : DEFAULT_BADGES_GAP
+    const wrap =
+      typeof node.properties.dataWrap === 'string' && isBadgesWrap(node.properties.dataWrap)
+        ? node.properties.dataWrap
+        : DEFAULT_BADGES_WRAP
+
+    node.properties.dataAlign = align
+    node.properties.dataGap = gap
+    node.properties.dataWrap = wrap
+    node.properties.className = mergeClassNames(
+      'not-prose',
+      'pmd-badges',
+      `pmd-badges--align-${align}`,
+      `pmd-badges--gap-${gap}`,
+      `pmd-badges--wrap-${wrap}`,
+    )
+  },
+  attributeValues: {
+    align: BADGES_ALIGNS,
+    gap: BADGES_GAPS,
+    wrap: BADGES_WRAPS,
+  },
+  defaultAttributes: {
+    align: DEFAULT_BADGES_ALIGN,
+    gap: DEFAULT_BADGES_GAP,
+    wrap: DEFAULT_BADGES_WRAP,
+  },
+  description: 'Badge group wrapper for one or more Shields badge directives.',
+  editor: {
+    detail: 'Badge group directive',
+    label: 'Badges',
+    snippet:
+      ':::badges{\n  align="${left}"\n  gap="${md}"\n  wrap=${true}\n}\n::badge[${npm version}]{\n  type="${npm}"\n  target="${version}"\n  package="${package-name}"\n}\n:::\n${}',
+  },
+  getMdastRenderProperties(node) {
+    return {
+      dataAlign: typeof node.attributes?.align === 'string' ? node.attributes.align : DEFAULT_BADGES_ALIGN,
+      dataDirective: 'badges',
+      dataGap: typeof node.attributes?.gap === 'string' ? node.attributes.gap : DEFAULT_BADGES_GAP,
+      dataWrap: typeof node.attributes?.wrap === 'string' ? node.attributes.wrap : DEFAULT_BADGES_WRAP,
+    }
+  },
+  kind: 'badges',
+  openMarker: ':::badges',
+  public: true,
+  supportsAttributes: true,
+  tagName: 'div',
+  validateAttributes({ attributes }) {
+    const warnings: string[] = []
+
+    if (typeof attributes.align === 'string' && !isBadgesAlign(attributes.align))
+      warnings.push(
+        `Invalid badges align "${attributes.align}". Falling back to "${DEFAULT_BADGES_ALIGN}".`,
+      )
+
+    if (typeof attributes.gap === 'string' && !isBadgesGap(attributes.gap))
+      warnings.push(
+        `Invalid badges gap "${attributes.gap}". Falling back to "${DEFAULT_BADGES_GAP}".`,
+      )
+
+    if (typeof attributes.wrap === 'string' && !isBadgesWrap(attributes.wrap))
+      warnings.push(
+        `Invalid badges wrap "${attributes.wrap}". Falling back to "${DEFAULT_BADGES_WRAP}".`,
+      )
+
+    return warnings
+  },
+}

--- a/src/directives/diagnostics.ts
+++ b/src/directives/diagnostics.ts
@@ -1,7 +1,9 @@
 import { normalizePayloadMarkdownIconRef } from '../icons/refs.js'
 import { hasUnclosedDirectiveAttributeBlock } from './attributes.js'
 import { parseButtonDirectiveLine } from './buttonSyntax.js'
+import { parseLeafDirectiveLine } from './leafSyntax.js'
 import { layoutDirectiveRegistry } from './registry.js'
+import { resolveShieldsBadge } from './shields.js'
 import { hasDirectiveTheme } from './themes.js'
 
 export type DirectiveDiagnostic = {
@@ -22,6 +24,8 @@ type OpenFrame = {
   tabCount?: number
   tabValues?: Map<string, number>
 }
+
+const SUPPORTED_LEAF_DIRECTIVE_NAMES = new Set(['badge', 'button'])
 
 function isFenceLine(trimmed: string): boolean {
   return trimmed.startsWith('```') || trimmed.startsWith('~~~')
@@ -282,6 +286,20 @@ function getButtonDiagnostics(text: string): string[] {
   return diagnostics
 }
 
+function getBadgeDiagnostics(text: string): string[] {
+  const parsed = parseLeafDirectiveLine(text, 'badge')
+  if (!parsed) return []
+
+  const definition = layoutDirectiveRegistry.get('badge')
+  const resolved = resolveShieldsBadge(parsed.attributes)
+
+  return [
+    ...parsed.warnings,
+    ...(definition?.validateAttributes?.({ name: 'badge', attributes: parsed.attributes }) ?? []),
+    ...resolved.warnings,
+  ]
+}
+
 function getLeafDirectiveName(text: string): string | undefined {
   if (text.startsWith(':::')) return undefined
 
@@ -351,7 +369,7 @@ export function lintMarkdownDirectives(markdown: string): DirectiveDiagnostic[] 
       const leafMarkerStart = line.indexOf('::')
       const leafMarkerFrom = leafMarkerStart >= 0 ? lineStart + leafMarkerStart : lineStart
 
-      if (leafName && leafName !== 'button')
+      if (leafName && !SUPPORTED_LEAF_DIRECTIVE_NAMES.has(leafName))
         diagnostics.push({
           from: leafMarkerFrom,
           line: index + 1,
@@ -361,6 +379,15 @@ export function lintMarkdownDirectives(markdown: string): DirectiveDiagnostic[] 
         })
 
       for (const message of getButtonDiagnostics(expandedTrimmed))
+        diagnostics.push({
+          from: leafMarkerFrom,
+          line: index + 1,
+          message,
+          severity: 'warning',
+          to: markerTo,
+        })
+
+      for (const message of getBadgeDiagnostics(expandedTrimmed))
         diagnostics.push({
           from: leafMarkerFrom,
           line: index + 1,

--- a/src/directives/leafSyntax.ts
+++ b/src/directives/leafSyntax.ts
@@ -1,0 +1,45 @@
+import type { DirectiveAttributes } from './attributes.js'
+
+import { parseDirectiveAttributesDetailed } from './attributes.js'
+
+export type ParsedLeafDirectiveLine = {
+  attributes: DirectiveAttributes
+  label: string
+  warnings: string[]
+}
+
+export function parseLeafDirectiveLine(
+  text: string,
+  name: string,
+): null | ParsedLeafDirectiveLine {
+  const trimmed = text.trim()
+  const marker = `::${name}`
+
+  if (!trimmed.startsWith(marker)) return null
+
+  let rest = trimmed.slice(marker.length)
+  if (rest && !/^[\s[{]/.test(rest)) return null
+
+  rest = rest.trimStart()
+  let label = ''
+
+  if (rest.startsWith('[')) {
+    const labelEnd = rest.indexOf(']')
+    if (labelEnd < 0) return null
+
+    label = rest.slice(1, labelEnd)
+    rest = rest.slice(labelEnd + 1).trimStart()
+  }
+
+  const rawAttributes = rest
+  if (rawAttributes && (!rawAttributes.startsWith('{') || !rawAttributes.endsWith('}')))
+    return null
+
+  const parsedAttributes = parseDirectiveAttributesDetailed(rawAttributes)
+
+  return {
+    attributes: parsedAttributes.attributes,
+    label,
+    warnings: parsedAttributes.warnings,
+  }
+}

--- a/src/directives/registry.ts
+++ b/src/directives/registry.ts
@@ -9,6 +9,8 @@ import type {
 import { normalizePayloadMarkdownIconRef } from '../icons/refs.js'
 import { getUnknownAttributeWarnings } from './attributeDiagnostics.js'
 import { parseDirectiveLine } from './attributes.js'
+import { badgeDirective } from './definitions/badge.js'
+import { badgesDirective } from './definitions/badges.js'
 import { buttonDirective } from './definitions/button.js'
 import { buttonsDirective } from './definitions/buttons.js'
 import { calloutDirective } from './definitions/callout.js'
@@ -29,6 +31,8 @@ const directiveDefinitions = [
   cellDirective,
   buttonDirective,
   buttonsDirective,
+  badgeDirective,
+  badgesDirective,
   calloutDirective,
   detailsDirective,
   tocDirective,

--- a/src/directives/shields.ts
+++ b/src/directives/shields.ts
@@ -1,0 +1,355 @@
+import type { DirectiveAttributes } from './attributes.js'
+
+export const SHIELDS_BADGE_ORIGIN = 'https://img.shields.io'
+
+export const SHIELDS_BADGE_QUERY_ATTRIBUTES = [
+  'style',
+  'logo',
+  'logoColor',
+  'logoSize',
+  'label',
+  'labelColor',
+  'color',
+  'cacheSeconds',
+] as const
+
+export type ShieldsBadgeResolution = {
+  src?: string
+  warnings: string[]
+}
+
+type ShieldsBadgeResolver = (attributes: DirectiveAttributes) => ShieldsBadgeResolution
+
+const NPM_DOWNLOAD_INTERVALS = ['dw', 'dm', 'dy', 'dt'] as const
+
+function getStringAttribute(attributes: DirectiveAttributes, name: string): string | undefined {
+  const value = attributes[name]
+
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function getRequiredStringAttributes(
+  attributes: DirectiveAttributes,
+  names: string[],
+): null | Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const name of names) {
+    const value = getStringAttribute(attributes, name)
+    if (!value) return null
+
+    out[name] = value
+  }
+
+  return out
+}
+
+function encodeStaticPathPart(value: string): string {
+  return encodeURIComponent(value).replace(/-/g, '%2D')
+}
+
+function normalizePathValue(value: string): string | undefined {
+  const trimmed = value.trim()
+
+  if (!trimmed) return undefined
+  if (hasUnsafePathCharacter(trimmed)) return undefined
+
+  const parts = trimmed.split('/')
+  if (parts.some((part) => part === '.' || part === '..')) return undefined
+
+  return parts.map((part) => encodeURIComponent(part)).join('/')
+}
+
+function hasUnsafePathCharacter(value: string): boolean {
+  for (const char of value) {
+    const charCode = char.charCodeAt(0)
+
+    if (charCode <= 31 || charCode === 127) return true
+    if (char === '\\' || char === '?' || char === '#') return true
+  }
+
+  return false
+}
+
+function addCommonQueryAttributes(
+  url: URL,
+  attributes: DirectiveAttributes,
+  excludedAttributes: readonly string[] = [],
+) {
+  const excluded = new Set(excludedAttributes)
+
+  for (const attribute of SHIELDS_BADGE_QUERY_ATTRIBUTES) {
+    if (excluded.has(attribute)) continue
+
+    const value = getStringAttribute(attributes, attribute)
+    if (value) url.searchParams.set(attribute, value)
+  }
+}
+
+function buildShieldsUrl(
+  path: string,
+  attributes: DirectiveAttributes,
+  excludedQueryAttributes: readonly string[] = [],
+): string {
+  const url = new URL(path.replace(/^\/+/, ''), `${SHIELDS_BADGE_ORIGIN}/`)
+
+  addCommonQueryAttributes(url, attributes, excludedQueryAttributes)
+
+  return url.toString()
+}
+
+function resolveStaticBadge(attributes: DirectiveAttributes): ShieldsBadgeResolution {
+  const required = getRequiredStringAttributes(attributes, ['label', 'message', 'color'])
+
+  if (!required)
+    return {
+      warnings: ['Directive "badge" requires label, message, and color for type="static".'],
+    }
+
+  return {
+    src: buildShieldsUrl(
+      `/badge/${encodeStaticPathPart(required.label)}-${encodeStaticPathPart(
+        required.message,
+      )}-${encodeStaticPathPart(required.color)}`,
+      attributes,
+      ['label', 'color'],
+    ),
+    warnings: [],
+  }
+}
+
+function resolveNpmBadge(attributes: DirectiveAttributes): ShieldsBadgeResolution {
+  const packageName = getStringAttribute(attributes, 'package')
+  const target = getStringAttribute(attributes, 'target')
+
+  if (!packageName)
+    return {
+      warnings: ['Directive "badge" requires package for type="npm".'],
+    }
+
+  const safePackageName = normalizePathValue(packageName)
+  if (!safePackageName)
+    return {
+      warnings: ['Directive "badge" package must be a safe Shields path value.'],
+    }
+
+  if (target === 'version')
+    return {
+      src: buildShieldsUrl(`/npm/v/${safePackageName}`, attributes, ['package']),
+      warnings: [],
+    }
+
+  if (target === 'downloads') {
+    const rawInterval = getStringAttribute(attributes, 'interval') ?? 'dw'
+    const interval = NPM_DOWNLOAD_INTERVALS.includes(
+      rawInterval as (typeof NPM_DOWNLOAD_INTERVALS)[number],
+    )
+      ? rawInterval
+      : 'dw'
+
+    return {
+      src: buildShieldsUrl(`/npm/${interval}/${safePackageName}`, attributes, [
+        'package',
+        'interval',
+      ]),
+      warnings:
+        interval === rawInterval
+          ? []
+          : [`Invalid badge interval "${rawInterval}". Falling back to "dw".`],
+    }
+  }
+
+  if (target === 'license')
+    return {
+      src: buildShieldsUrl(`/npm/l/${safePackageName}`, attributes, ['package']),
+      warnings: [],
+    }
+
+  return {
+    warnings: [
+      target
+        ? `Unsupported badge target "${target}" for type="npm".`
+        : 'Directive "badge" requires target for type="npm".',
+    ],
+  }
+}
+
+function resolveGithubBadge(attributes: DirectiveAttributes): ShieldsBadgeResolution {
+  const repo = getStringAttribute(attributes, 'repo')
+  const target = getStringAttribute(attributes, 'target')
+
+  if (!repo)
+    return {
+      warnings: ['Directive "badge" requires repo for type="github".'],
+    }
+
+  const safeRepo = normalizePathValue(repo)
+  if (!safeRepo)
+    return {
+      warnings: ['Directive "badge" repo must be a safe Shields path value.'],
+    }
+
+  if (target === 'workflow') {
+    const workflow = getStringAttribute(attributes, 'workflow')
+
+    if (!workflow)
+      return {
+        warnings: ['Directive "badge" requires workflow for type="github" target="workflow".'],
+      }
+
+    const safeWorkflow = normalizePathValue(workflow)
+    if (!safeWorkflow)
+      return {
+        warnings: ['Directive "badge" workflow must be a safe Shields path value.'],
+      }
+
+    return {
+      src: buildShieldsUrl(
+        `/github/actions/workflow/status/${safeRepo}/${safeWorkflow}`,
+        attributes,
+        ['repo', 'workflow'],
+      ),
+      warnings: [],
+    }
+  }
+
+  if (target === 'release')
+    return {
+      src: buildShieldsUrl(`/github/v/release/${safeRepo}`, attributes, ['repo']),
+      warnings: [],
+    }
+
+  if (target === 'license')
+    return {
+      src: buildShieldsUrl(`/github/license/${safeRepo}`, attributes, ['repo']),
+      warnings: [],
+    }
+
+  if (target === 'stars')
+    return {
+      src: buildShieldsUrl(`/github/stars/${safeRepo}`, attributes, ['repo']),
+      warnings: [],
+    }
+
+  return {
+    warnings: [
+      target
+        ? `Unsupported badge target "${target}" for type="github".`
+        : 'Directive "badge" requires target for type="github".',
+    ],
+  }
+}
+
+function resolveDebianBadge(attributes: DirectiveAttributes): ShieldsBadgeResolution {
+  const packageName = getStringAttribute(attributes, 'package')
+  const target = getStringAttribute(attributes, 'target')
+
+  if (!target)
+    return {
+      warnings: ['Directive "badge" requires target for type="debian".'],
+    }
+
+  if (target !== 'version')
+    return {
+      warnings: [`Unsupported badge target "${target}" for type="debian".`],
+    }
+
+  if (!packageName)
+    return {
+      warnings: ['Directive "badge" requires package for type="debian".'],
+    }
+
+  const safePackageName = normalizePathValue(packageName)
+  if (!safePackageName)
+    return {
+      warnings: ['Directive "badge" package must be a safe Shields path value.'],
+    }
+
+  return {
+    src: buildShieldsUrl(`/debian/v/${safePackageName}`, attributes, ['package']),
+    warnings: [],
+  }
+}
+
+export const shieldsBadgeResolvers: Record<string, ShieldsBadgeResolver> = {
+  apt: resolveDebianBadge,
+  debian: resolveDebianBadge,
+  github: resolveGithubBadge,
+  npm: resolveNpmBadge,
+  static: resolveStaticBadge,
+}
+
+function resolveSrcEscapeHatch(attributes: DirectiveAttributes): null | ShieldsBadgeResolution {
+  const src = getStringAttribute(attributes, 'src')
+
+  if (!src) return null
+
+  try {
+    const url = new URL(src)
+
+    if (
+      url.origin !== SHIELDS_BADGE_ORIGIN ||
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password
+    )
+      return {
+        warnings: ['Directive "badge" src must use https://img.shields.io/.'],
+      }
+
+    addCommonQueryAttributes(url, attributes)
+
+    return {
+      src: url.toString(),
+      warnings: [],
+    }
+  } catch {
+    return {
+      warnings: ['Directive "badge" src must be a valid https://img.shields.io/ URL.'],
+    }
+  }
+}
+
+function resolvePathEscapeHatch(attributes: DirectiveAttributes): null | ShieldsBadgeResolution {
+  const path = getStringAttribute(attributes, 'path')
+
+  if (!path) return null
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith('//'))
+    return {
+      warnings: ['Directive "badge" path must be a Shields path, not a URL.'],
+    }
+
+  const normalizedPath = normalizePathValue(path.replace(/^\/+/, ''))
+  if (!normalizedPath)
+    return {
+      warnings: ['Directive "badge" path must be a safe Shields path value.'],
+    }
+
+  return {
+    src: buildShieldsUrl(normalizedPath, attributes),
+    warnings: [],
+  }
+}
+
+export function resolveShieldsBadge(attributes: DirectiveAttributes): ShieldsBadgeResolution {
+  const srcResolved = resolveSrcEscapeHatch(attributes)
+  if (srcResolved) return srcResolved
+
+  const pathResolved = resolvePathEscapeHatch(attributes)
+  if (pathResolved) return pathResolved
+
+  const type = getStringAttribute(attributes, 'type')
+
+  if (!type)
+    return {
+      warnings: ['Directive "badge" requires type, path, or src.'],
+    }
+
+  const resolver = shieldsBadgeResolvers[type]
+  if (!resolver)
+    return {
+      warnings: [`Unsupported badge type "${type}".`],
+    }
+
+  return resolver(attributes)
+}

--- a/src/directives/types.ts
+++ b/src/directives/types.ts
@@ -7,6 +7,8 @@ import type { DirectiveThemeGroupName, ResolvedDirectiveTheme } from './themes.j
 
 export type LayoutDirectiveName = '2col' | '3col' | 'cell' | 'section'
 export type StaticDirectiveName =
+  | 'badge'
+  | 'badges'
   | 'button'
   | 'buttons'
   | 'callout'
@@ -50,6 +52,8 @@ export type DirectiveChild = ContainerDirective['children'][number]
 export type MarkdownDirectiveNode = ContainerDirective | LeafDirective
 
 export type LayoutDirectiveKind =
+  | 'badge'
+  | 'badges'
   | 'button'
   | 'buttons'
   | 'callout'
@@ -69,6 +73,7 @@ export type LayoutDirectiveRenderTagName =
   | 'article'
   | 'details'
   | 'div'
+  | 'img'
   | 'nav'
   | 'section'
 

--- a/src/editor/directives/completions.ts
+++ b/src/editor/directives/completions.ts
@@ -37,7 +37,7 @@ export function getDirectiveCompletionOptions() {
 export function getDirectiveAttributeCompletionOptions(name: string): Completion[] {
   const definition = layoutDirectiveRegistry.get(name)
   const attributes = definition?.allowedAttributes ?? []
-  const detailPrefix = name === 'button' ? '::button' : `:::${name}`
+  const detailPrefix = name === 'button' || name === 'badge' ? `::${name}` : `:::${name}`
 
   return attributes.map((attribute) =>
     snippetCompletion(`${attribute}="\${${attribute}}"`, {
@@ -54,7 +54,7 @@ export function getDirectiveThemeValueCompletionOptions(
 ): Completion[] {
   const definition = layoutDirectiveRegistry.get(name)
   const groupName = definition?.themeAttributes?.[attribute]
-  const detailPrefix = name === 'button' ? '::button' : `:::${name}`
+  const detailPrefix = name === 'button' || name === 'badge' ? `::${name}` : `:::${name}`
 
   if (!groupName)
     return (definition?.attributeValues?.[attribute] ?? []).map((value) => ({
@@ -74,9 +74,9 @@ function attributeCompletionSource(context: CompletionContext) {
   const line = context.state.doc.lineAt(context.pos)
   const beforeCursor = line.text.slice(0, context.pos - line.from)
   const containerMatch = beforeCursor.match(/^\s*:::(\w+)(?:\[[^\]]*\])?\s*\{([^}]*)$/)
-  const buttonMatch = beforeCursor.match(/^\s*::button(?:\[[^\]]*\])?\s*\{([^}]*)$/)
+  const leafMatch = beforeCursor.match(/^\s*::(button|badge)(?:\[[^\]]*\])?\s*\{([^}]*)$/)
   const multilineMatch =
-    containerMatch || buttonMatch
+    containerMatch || leafMatch
       ? null
       : findOpenDirectiveAttributeBlock(context, beforeCursor)
   const directiveMatch = containerMatch
@@ -84,10 +84,10 @@ function attributeCompletionSource(context: CompletionContext) {
         name: containerMatch[1],
         attributesBeforeCursor: containerMatch[2],
       }
-    : buttonMatch
+    : leafMatch
       ? {
-          name: 'button',
-          attributesBeforeCursor: buttonMatch[1],
+          name: leafMatch[1],
+          attributesBeforeCursor: leafMatch[2],
         }
       : multilineMatch
 
@@ -95,7 +95,7 @@ function attributeCompletionSource(context: CompletionContext) {
 
   const { name, attributesBeforeCursor } = directiveMatch
   const valueMatch = attributesBeforeCursor.match(
-    /(?:^|\s)(align|gap|theme|cardTheme|cellTheme|iconPosition|linkScope|newTab|size|stack|stepTheme|tabTheme|variant)=["']?([^"'\s}]*)$/,
+    /(?:^|\s)(align|gap|theme|cardTheme|cellTheme|iconPosition|interval|linkScope|newTab|size|stack|stepTheme|style|tabTheme|target|type|variant|wrap)=["']?([^"'\s}]*)$/,
   )
 
   if (valueMatch) {
@@ -143,10 +143,10 @@ function findOpenDirectiveAttributeBlock(
         attributesBeforeCursor,
       }
 
-    const buttonMatch = previousLine.match(/^\s*::button(?:\[[^\]]*\])?\s*\{/)
-    if (buttonMatch)
+    const leafMatch = previousLine.match(/^\s*::(button|badge)(?:\[[^\]]*\])?\s*\{/)
+    if (leafMatch)
       return {
-        name: 'button',
+        name: leafMatch[1],
         attributesBeforeCursor,
       }
   }

--- a/src/editor/themes/payload.ts
+++ b/src/editor/themes/payload.ts
@@ -251,7 +251,7 @@ function isDirectiveLine(line: MarkdownLine): boolean {
 }
 
 function isLeafDirectiveLine(line: MarkdownLine): boolean {
-  return /^::button(?:$|[\s[{])/.test(line.text.slice(line.pos))
+  return /^::(?:button|badge)(?:$|[\s[{])/.test(line.text.slice(line.pos))
 }
 
 function skipInlineSpace(text: string, index: number): number {
@@ -375,7 +375,9 @@ function parseDirectiveLineElements(
   const text = line.text
   const start = line.pos
   const lineStart = cxLineStart(cx)
-  const directiveMatch = text.slice(start).match(leaf ? /^::button(?=$|[\s[{])/ : /^:::[\w-]*/)
+  const directiveMatch = text
+    .slice(start)
+    .match(leaf ? /^::(?:button|badge)(?=$|[\s[{])/ : /^:::[\w-]*/)
   const directiveText = directiveMatch?.[0]?.trimEnd()
 
   if (!directiveText) return []


### PR DESCRIPTION
This pull request introduces comprehensive support for Shields-style badges in markdown, including new `::badge` and `:::badges` directives, extensive parsing and rendering logic, and thorough test coverage. It also includes some minor refactoring and configuration updates. The main focus is on enabling users to easily add and customize badges in documentation using markdown directives.

**Badge and Badges Directive Support**

- **New badge directives and documentation:**  
  Added support for `::badge` (leaf) and `:::badges` (container) markdown directives, with detailed documentation and usage examples for various badge types (npm, GitHub, Debian, static, etc.) in `.agents/skills/payload-markdown-docs/reference/payload-markdown-directives.md`.

- **Parsing, highlighting, and completion:**  
  Updated the directive registry and tests to recognize `badge` and `badges` as valid directives, parse their attributes, and provide completion options and theme values for their attributes in the editor. [[1]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R552-R553) [[2]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R587-R593) [[3]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R829-R830) [[4]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R852-R853) [[5]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R888) [[6]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R904-R907) [[7]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R941-R950)

- **Rendering and validation tests:**  
  Added extensive integration tests to ensure correct HTML rendering, attribute handling, badge URL generation for all supported types, wrapper alignment/gap/wrap class application, and proper diagnostics for invalid attributes or missing required fields. [[1]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R1217-R1381) [[2]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R2635-R2638) [[3]](diffhunk://#diff-34a6cb870de341a62ed64d1145a7cd0359b9563863f0f4d57d44bfc95422d760R2679-R2680)

**Project Configuration and Refactoring**

- **Refactored imports for Markdown block component:**  
  Changed import source for `MarkdownBlockComponent` in `dev/blocks/RenderBlocks.tsx` to reference the local source directory, likely to facilitate development or local testing.

- **Payload types cleanup:**  
  Removed unused or redundant fields (`centered`, `prettyCodeBlocks`, `highlightLines`) and renamed `prettyCodeBlocks` to `enhancedCodeBlocks` in the payload types, streamlining the markdown block configuration. [[1]](diffhunk://#diff-09076bbef7e711f425e5a553016470e3d89457fca616f6a7f5a44e0bf73d1ba4L240-L243) [[2]](diffhunk://#diff-09076bbef7e711f425e5a553016470e3d89457fca616f6a7f5a44e0bf73d1ba4L336-R332) [[3]](diffhunk://#diff-09076bbef7e711f425e5a553016470e3d89457fca616f6a7f5a44e0bf73d1ba4L614) [[4]](diffhunk://#diff-09076bbef7e711f425e5a553016470e3d89457fca616f6a7f5a44e0bf73d1ba4L623-R614)

- **Update to payload markdown import:**  
  Updated the import path for `payloadMarkdown` and `DEFAULT_CODE_LANGS` in `dev/payload.config.ts` to use the local `dist` directory instead of the package, likely for local development purposes.

- **Minor Next.js config update:**  
  Added `allowedDevOrigins` to the Next.js config for development environment flexibility.